### PR TITLE
Fix clippy workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: cargo clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --workspace --examples --tests -- -D warnings

--- a/src/store.rs
+++ b/src/store.rs
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn mem_buf_store_eqv() {
         const LEN: usize = 4;
-        let blocks: Vec<_> = (0..LEN).into_iter().map(create_block_raw).collect();
+        let blocks: Vec<_> = (0..LEN).map(create_block_raw).collect();
         model! {
             Model => let mem_store = MemStore::default(),
             Implementation => let buf_store = BufStore::new(MemStore::default(), 16, 16),


### PR DESCRIPTION
This is similar to https://github.com/ipfs-rust/rust-ipfs/pull/156, I noticed that clippy was only ran on the root crate instead of the whole workspace, tests and examples.