### PR TITLE
Allow custom code tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cid"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50720fbd95ce5d9e51b6b81b7e4f5f93efdefb4b83aa46200dfc9fdfcd84b379"
+checksum = "8709d481fb78b9808f34a1b4b4fadd08a15a0971052c18bc2b751faefaed595e"
 dependencies = [
  "multibase",
  "multihash",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ description = "Base traits and definitions used by ipld codecs."
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
 [dependencies]
-cid = "0.5.0"
+cid = "0.5.1"
 multibase = "0.8.0"
 multihash = "0.11.2"
 thiserror = "1.0.19"

--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -4,47 +4,47 @@ use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 /// Codec trait.
-pub trait Codec<D = Code>: Sized
+pub trait Codec<C = Code>: Sized
 where
-    D: Copy + TryFrom<u64> + Into<u64>,
+    C: Copy + TryFrom<u64> + Into<u64>,
 {
     /// Codec code.
-    const CODE: D;
+    const CODE: C;
 
     /// Error type.
     type Error: std::error::Error + Send + 'static;
 
     /// Encodes an encodable type.
-    fn encode<T: Encode<Self, D> + ?Sized>(obj: &T) -> Result<Box<[u8]>, Self::Error> {
+    fn encode<T: Encode<Self, C> + ?Sized>(obj: &T) -> Result<Box<[u8]>, Self::Error> {
         let mut buf = Vec::new();
         obj.encode(&mut buf)?;
         Ok(buf.into_boxed_slice())
     }
 
     /// Decodes a decodable type.
-    fn decode<T: Decode<Self, D>>(mut bytes: &[u8]) -> Result<T, Self::Error> {
+    fn decode<T: Decode<Self, C>>(mut bytes: &[u8]) -> Result<T, Self::Error> {
         T::decode(&mut bytes)
     }
 }
 
 /// Encode trait.
-pub trait Encode<C, D = Code>
+pub trait Encode<O, C = Code>
 where
-    C: Codec<D>,
-    D: Copy + TryFrom<u64> + Into<u64>,
+    O: Codec<C>,
+    C: Copy + TryFrom<u64> + Into<u64>,
 {
     /// Encodes into a `impl Write`.
-    fn encode<W: Write>(&self, w: &mut W) -> Result<(), C::Error>;
+    fn encode<W: Write>(&self, w: &mut W) -> Result<(), O::Error>;
 }
 
 /// Decode trait.
-pub trait Decode<C, D = Code>: Sized
+pub trait Decode<O, C = Code>: Sized
 where
-    C: Codec<D>,
-    D: Copy + TryFrom<u64> + Into<u64>,
+    O: Codec<C>,
+    C: Copy + TryFrom<u64> + Into<u64>,
 {
     /// Decode from an `impl Read`.
-    fn decode<R: Read>(r: &mut R) -> Result<Self, C::Error>;
+    fn decode<R: Read>(r: &mut R) -> Result<Self, O::Error>;
 }
 
 #[cfg(test)]

--- a/core/src/convert.rs
+++ b/core/src/convert.rs
@@ -6,7 +6,11 @@ use std::convert::TryFrom;
 
 macro_rules! derive_to_ipld_prim {
     ($enum:ident, $ty:ty, $fn:ident) => {
-        impl From<$ty> for Ipld {
+        impl<C, H> From<$ty> for Ipld<C, H>
+        where
+            C: Into<u64> + TryFrom<u64> + Copy,
+            H: Into<u64> + TryFrom<u64> + Copy,
+        {
             fn from(t: $ty) -> Self {
                 Ipld::$enum(t.$fn() as _)
             }
@@ -16,7 +20,11 @@ macro_rules! derive_to_ipld_prim {
 
 macro_rules! derive_to_ipld {
     ($enum:ident, $ty:ty, $($fn:ident),*) => {
-        impl From<$ty> for Ipld {
+        impl<C, H> From<$ty> for Ipld<C, H>
+        where
+            C: Into<u64> + TryFrom<u64> + Copy,
+            H: Into<u64> + TryFrom<u64> + Copy,
+        {
             fn from(t: $ty) -> Self {
                 Ipld::$enum(t$(.$fn())*)
             }
@@ -57,7 +65,7 @@ derive_to_ipld!(String, &str, to_string);
 derive_to_ipld!(Bytes, Box<[u8]>, into_vec);
 derive_to_ipld!(Bytes, Vec<u8>, into);
 derive_to_ipld!(Bytes, &[u8], to_vec);
-derive_to_ipld!(List, Vec<Ipld>, into);
-derive_to_ipld!(Map, BTreeMap<String, Ipld>, to_owned);
+derive_to_ipld!(List, Vec<Ipld<C, H>>, into);
+derive_to_ipld!(Map, BTreeMap<String, Ipld<C, H>>, to_owned);
 derive_to_ipld_generic!(Link, CidGeneric<C, H>, clone);
 derive_to_ipld_generic!(Link, &CidGeneric<C, H>, to_owned);

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,5 +1,6 @@
 //! `Ipld` error definitions.
 use crate::ipld::{Ipld, IpldIndex};
+use std::convert::TryFrom;
 use thiserror::Error;
 
 /// Type error.
@@ -49,8 +50,12 @@ pub enum TypeErrorType {
     Index(usize),
 }
 
-impl From<&Ipld> for TypeErrorType {
-    fn from(ipld: &Ipld) -> Self {
+impl<C, H> From<&Ipld<C, H>> for TypeErrorType
+where
+    C: Into<u64> + TryFrom<u64> + Copy,
+    H: Into<u64> + TryFrom<u64> + Copy,
+{
+    fn from(ipld: &Ipld<C, H>) -> Self {
         match ipld {
             Ipld::Null => Self::Null,
             Ipld::Bool(_) => Self::Bool,

--- a/core/src/raw.rs
+++ b/core/src/raw.rs
@@ -2,6 +2,7 @@
 use crate::codec::{Code, Codec, Decode, Encode};
 use crate::error::{TypeError, TypeErrorType};
 use crate::ipld::Ipld;
+use std::convert::TryFrom;
 use std::io::{Read, Write};
 use thiserror::Error;
 
@@ -43,7 +44,11 @@ impl Encode<RawCodec> for Vec<u8> {
     }
 }
 
-impl Encode<RawCodec> for Ipld {
+impl<C, H> Encode<RawCodec> for Ipld<C, H>
+where
+    C: Copy + TryFrom<u64> + Into<u64>,
+    H: Copy + TryFrom<u64> + Into<u64>,
+{
     fn encode<W: Write>(&self, w: &mut W) -> Result<(), RawError> {
         if let Ipld::Bytes(bytes) = self {
             bytes.encode(w)
@@ -68,7 +73,11 @@ impl Decode<RawCodec> for Vec<u8> {
     }
 }
 
-impl Decode<RawCodec> for Ipld {
+impl<C, H> Decode<RawCodec> for Ipld<C, H>
+where
+    C: Copy + TryFrom<u64> + Into<u64>,
+    H: Copy + TryFrom<u64> + Into<u64>,
+{
     fn decode<R: Read>(r: &mut R) -> Result<Self, RawError> {
         let bytes: Vec<u8> = Decode::<RawCodec>::decode(r)?;
         Ok(Ipld::Bytes(bytes))

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -439,39 +439,39 @@ where
     fn try_read_cbor<R: Read>(r: &mut R, major: u8) -> Result<Option<Self>> {
         let ipld = match major {
             // Major type 0: an unsigned integer
-            0x00..=0x17 => Ipld::<C, H>::Integer(major as i128),
-            0x18 => Ipld::<C, H>::Integer(read_u8(r)? as i128),
-            0x19 => Ipld::<C, H>::Integer(read_u16(r)? as i128),
-            0x1a => Ipld::<C, H>::Integer(read_u32(r)? as i128),
-            0x1b => Ipld::<C, H>::Integer(read_u64(r)? as i128),
+            0x00..=0x17 => Self::Integer(major as i128),
+            0x18 => Self::Integer(read_u8(r)? as i128),
+            0x19 => Self::Integer(read_u16(r)? as i128),
+            0x1a => Self::Integer(read_u32(r)? as i128),
+            0x1b => Self::Integer(read_u64(r)? as i128),
 
             // Major type 1: a negative integer
-            0x20..=0x37 => Ipld::<C, H>::Integer(-1 - (major - 0x20) as i128),
-            0x38 => Ipld::<C, H>::Integer(-1 - read_u8(r)? as i128),
-            0x39 => Ipld::<C, H>::Integer(-1 - read_u16(r)? as i128),
-            0x3a => Ipld::<C, H>::Integer(-1 - read_u32(r)? as i128),
-            0x3b => Ipld::<C, H>::Integer(-1 - read_u64(r)? as i128),
+            0x20..=0x37 => Self::Integer(-1 - (major - 0x20) as i128),
+            0x38 => Self::Integer(-1 - read_u8(r)? as i128),
+            0x39 => Self::Integer(-1 - read_u16(r)? as i128),
+            0x3a => Self::Integer(-1 - read_u32(r)? as i128),
+            0x3b => Self::Integer(-1 - read_u64(r)? as i128),
 
             // Major type 2: a byte string
             0x40..=0x57 => {
                 let len = major - 0x40;
                 let bytes = read_bytes(r, len as usize)?;
-                Ipld::<C, H>::Bytes(bytes)
+                Self::Bytes(bytes)
             }
             0x58 => {
                 let len = read_u8(r)?;
                 let bytes = read_bytes(r, len as usize)?;
-                Ipld::<C, H>::Bytes(bytes)
+                Self::Bytes(bytes)
             }
             0x59 => {
                 let len = read_u16(r)?;
                 let bytes = read_bytes(r, len as usize)?;
-                Ipld::<C, H>::Bytes(bytes)
+                Self::Bytes(bytes)
             }
             0x5a => {
                 let len = read_u32(r)?;
                 let bytes = read_bytes(r, len as usize)?;
-                Ipld::<C, H>::Bytes(bytes)
+                Self::Bytes(bytes)
             }
             0x5b => {
                 let len = read_u64(r)?;
@@ -479,29 +479,29 @@ where
                     return Err(Error::LengthOutOfRange);
                 }
                 let bytes = read_bytes(r, len as usize)?;
-                Ipld::<C, H>::Bytes(bytes)
+                Self::Bytes(bytes)
             }
 
             // Major type 3: a text string
             0x60..=0x77 => {
                 let len = major - 0x60;
                 let string = read_str(r, len as usize)?;
-                Ipld::<C, H>::String(string)
+                Self::String(string)
             }
             0x78 => {
                 let len = read_u8(r)?;
                 let string = read_str(r, len as usize)?;
-                Ipld::<C, H>::String(string)
+                Self::String(string)
             }
             0x79 => {
                 let len = read_u16(r)?;
                 let string = read_str(r, len as usize)?;
-                Ipld::<C, H>::String(string)
+                Self::String(string)
             }
             0x7a => {
                 let len = read_u32(r)?;
                 let string = read_str(r, len as usize)?;
-                Ipld::<C, H>::String(string)
+                Self::String(string)
             }
             0x7b => {
                 let len = read_u64(r)?;
@@ -509,29 +509,29 @@ where
                     return Err(Error::LengthOutOfRange);
                 }
                 let string = read_str(r, len as usize)?;
-                Ipld::<C, H>::String(string)
+                Self::String(string)
             }
 
             // Major type 4: an array of data items
             0x80..=0x97 => {
                 let len = major - 0x80;
                 let list = read_list(r, len as usize)?;
-                Ipld::<C, H>::List(list)
+                Self::List(list)
             }
             0x98 => {
                 let len = read_u8(r)?;
                 let list = read_list(r, len as usize)?;
-                Ipld::<C, H>::List(list)
+                Self::List(list)
             }
             0x99 => {
                 let len = read_u16(r)?;
                 let list = read_list(r, len as usize)?;
-                Ipld::<C, H>::List(list)
+                Self::List(list)
             }
             0x9a => {
                 let len = read_u32(r)?;
                 let list = read_list(r, len as usize)?;
-                Ipld::<C, H>::List(list)
+                Self::List(list)
             }
             0x9b => {
                 let len = read_u64(r)?;
@@ -539,29 +539,29 @@ where
                     return Err(Error::LengthOutOfRange);
                 }
                 let list = read_list(r, len as usize)?;
-                Ipld::<C, H>::List(list)
+                Self::List(list)
             }
 
             // Major type 5: a map of pairs of data items
             0xa0..=0xb7 => {
                 let len = major - 0xa0;
                 let map = read_map(r, len as usize)?;
-                Ipld::<C, H>::Map(map)
+                Self::Map(map)
             }
             0xb8 => {
                 let len = read_u8(r)?;
                 let map = read_map(r, len as usize)?;
-                Ipld::<C, H>::Map(map)
+                Self::Map(map)
             }
             0xb9 => {
                 let len = read_u16(r)?;
                 let map = read_map(r, len as usize)?;
-                Ipld::<C, H>::Map(map)
+                Self::Map(map)
             }
             0xba => {
                 let len = read_u32(r)?;
                 let map = read_map(r, len as usize)?;
-                Ipld::<C, H>::Map(map)
+                Self::Map(map)
             }
             0xbb => {
                 let len = read_u64(r)?;
@@ -569,19 +569,19 @@ where
                     return Err(Error::LengthOutOfRange);
                 }
                 let map = read_map(r, len as usize)?;
-                Ipld::<C, H>::Map(map)
+                Self::Map(map)
             }
 
             // Major type 6: optional semantic tagging of other major types
-            0xd8 => Ipld::<C, H>::Link(read_link(r)?),
+            0xd8 => Self::Link(read_link(r)?),
 
             // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4 => Ipld::<C, H>::Bool(false),
-            0xf5 => Ipld::<C, H>::Bool(true),
-            0xf6 => Ipld::<C, H>::Null,
-            0xf7 => Ipld::<C, H>::Null,
-            0xfa => Ipld::<C, H>::Float(read_f32(r)? as f64),
-            0xfb => Ipld::<C, H>::Float(read_f64(r)?),
+            0xf4 => Self::Bool(false),
+            0xf5 => Self::Bool(true),
+            0xf6 => Self::Null,
+            0xf7 => Self::Null,
+            0xfa => Self::Float(read_f32(r)? as f64),
+            0xfb => Self::Float(read_f64(r)?),
             _ => return Ok(None),
         };
         Ok(Some(ipld))

--- a/dag-cbor/src/encode.rs
+++ b/dag-cbor/src/encode.rs
@@ -260,15 +260,15 @@ where
 {
     fn encode<W: Write>(&self, w: &mut W) -> Result<()> {
         match self {
-            Ipld::<C, H>::Null => write_null(w),
-            Ipld::<C, H>::Bool(b) => Encode::<DagCbor>::encode(b, w),
-            Ipld::<C, H>::Integer(i) => Encode::<DagCbor>::encode(i, w),
-            Ipld::<C, H>::Float(f) => Encode::<DagCbor>::encode(f, w),
-            Ipld::<C, H>::Bytes(b) => Encode::<DagCbor>::encode(b.as_slice(), w),
-            Ipld::<C, H>::String(s) => Encode::<DagCbor>::encode(s, w),
-            Ipld::<C, H>::List(l) => Encode::<DagCbor>::encode(l, w),
-            Ipld::<C, H>::Map(m) => Encode::<DagCbor>::encode(m, w),
-            Ipld::<C, H>::Link(c) => Encode::<DagCbor>::encode(c, w),
+            Self::Null => write_null(w),
+            Self::Bool(b) => Encode::<DagCbor>::encode(b, w),
+            Self::Integer(i) => Encode::<DagCbor>::encode(i, w),
+            Self::Float(f) => Encode::<DagCbor>::encode(f, w),
+            Self::Bytes(b) => Encode::<DagCbor>::encode(b.as_slice(), w),
+            Self::String(s) => Encode::<DagCbor>::encode(s, w),
+            Self::List(l) => Encode::<DagCbor>::encode(l, w),
+            Self::Map(m) => Encode::<DagCbor>::encode(m, w),
+            Self::Link(c) => Encode::<DagCbor>::encode(c, w),
         }
     }
 }

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -4,7 +4,9 @@
 
 use libipld_core::codec::{Code, Codec, Decode, Encode};
 use libipld_core::ipld::Ipld;
-use serde_json::Error;
+// TODO vmx 2020-05-28: Don't expose the `serde_json` error directly, but wrap it in a custom one
+pub use serde_json::Error;
+use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 mod codec;
@@ -19,13 +21,21 @@ impl Codec for DagJsonCodec {
     type Error = Error;
 }
 
-impl Encode<DagJsonCodec> for Ipld {
+impl<C, H> Encode<DagJsonCodec> for Ipld<C, H>
+where
+    C: Into<u64> + TryFrom<u64> + Copy,
+    H: Into<u64> + TryFrom<u64> + Copy,
+{
     fn encode<W: Write>(&self, w: &mut W) -> Result<(), Error> {
         codec::encode(self, w)
     }
 }
 
-impl Decode<DagJsonCodec> for Ipld {
+impl<C, H> Decode<DagJsonCodec> for Ipld<C, H>
+where
+    C: Into<u64> + TryFrom<u64> + Copy,
+    H: Into<u64> + TryFrom<u64> + Copy,
+{
     fn decode<R: Read>(r: &mut R) -> Result<Self, Error> {
         codec::decode(r)
     }

--- a/dag-pb/src/lib.rs
+++ b/dag-pb/src/lib.rs
@@ -6,6 +6,7 @@ pub use crate::codec::{PbLink, PbNode};
 use core::convert::TryInto;
 use libipld_core::codec::{Code, Codec, Decode, Encode};
 use libipld_core::ipld::Ipld;
+use std::convert::TryFrom;
 use std::io::{Read, Write};
 use thiserror::Error;
 
@@ -38,16 +39,24 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
-impl Encode<DagPbCodec> for Ipld {
+impl<C, H> Encode<DagPbCodec> for Ipld<C, H>
+where
+    C: Into<u64> + TryFrom<u64> + Copy,
+    H: Into<u64> + TryFrom<u64> + Copy,
+{
     fn encode<W: Write>(&self, w: &mut W) -> Result<(), Error> {
-        let pb_node: PbNode = self.try_into()?;
+        let pb_node: PbNode<C, H> = self.try_into()?;
         let bytes = pb_node.into_bytes();
         w.write_all(&bytes)?;
         Ok(())
     }
 }
 
-impl Decode<DagPbCodec> for Ipld {
+impl<C, H> Decode<DagPbCodec> for Ipld<C, H>
+where
+    C: Into<u64> + TryFrom<u64> + Copy,
+    H: Into<u64> + TryFrom<u64> + Copy,
+{
     fn decode<R: Read>(r: &mut R) -> Result<Self, Error> {
         let mut bytes = Vec::new();
         r.read_to_end(&mut bytes)?;

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -50,7 +50,7 @@
 ///     "comma -->",
 /// ]);
 /// ```
-pub use libipld_core::cid::Cid;
+pub use libipld_core::cid::{Cid, Codec as CCode};
 pub use libipld_core::ipld::Ipld;
 
 #[macro_export(local_inner_macros)]
@@ -268,7 +268,7 @@ macro_rules! ipld_internal {
     // Must be below every other rule.
     ($other:expr) => {
         {
-            $crate::Ipld::from($other)
+            $crate::Ipld::<$crate::CCode>::from($other)
         }
     };
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 //! `Ipld` error definitions.
 use crate::cid::Cid;
-use crate::multihash::Multihash;
 pub use libipld_core::error::*;
 use thiserror::Error;
 
@@ -15,10 +14,12 @@ pub enum Error {
     BlockTooLarge(usize),
     /// Hash does not match the CID.
     #[error("Hash does not match the CID.")]
-    InvalidHash(Multihash),
+    // It is a Multihash, but it's already converted into bytes when reported, so that we
+    // don't need to bubble up all the generics into `Error`
+    InvalidHash(Vec<u8>),
     /// The codec is unsupported.
     #[error("Unsupported codec {0:?}.")]
-    UnsupportedCodec(crate::codec::Code),
+    UnsupportedCodec(u64),
     /// The multihash is unsupported.
     #[error("Unsupported multihash {0:?}.")]
     UnsupportedMultihash(crate::multihash::Code),


### PR DESCRIPTION
This PR makes `Ipld` generic over code tables. This way you can use IPLD with custom code tables.

For example, by default we should use a specific code table for codecs that are supported by this library instead of using the one bundled with rust-cid. Though, upstream users, e.g. IPFS might want to bundle a different set of codecs, that might even live in external crates. With this change such custom codecs, with their own code table can be used without any modifications of this library.

Not all of the code is fully generic yet. The `MemStore` and parts of `src/block.rs` are missing. Those currently only work with the default codec table.

This PR sets the ground for the Block API I'm working. There are more changes I'd like to make, which follow in future PRs. But I want to keep the PRs self contained, so that issues can easier be discussed.