### PR TITLE
feat: Block API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,8 +778,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75db05d738947aa5389863aadafbcf2e509d7ba099dc2ddcdf4fc66bf7a9e03"
+source = "git+https://github.com/multiformats/rust-multihash?branch=digestfromcode-trait#91fadc082be809833623c1701fa3f3071994078d"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ harness = false
 [[bench]]
 name = "store"
 harness = false
+
+[patch.crates-io]
+multihash = { git  = "https://github.com/multiformats/rust-multihash", branch = "digestfromcode-trait" }

--- a/src/block.rs
+++ b/src/block.rs
@@ -105,7 +105,6 @@ where
         if let Some(node) = &self.node {
             Ok(node.clone())
         } else if let Some(raw) = &self.raw {
-            //let decoded = Box::<dyn DynIpldCodec>::from(Box::new(self.codec))._decode(&raw).unwrap();
             let decoded = self.codec.decode(&raw).unwrap();
             self.node = Some(decoded.clone());
             Ok(decoded)
@@ -122,10 +121,6 @@ where
         if let Some(raw) = &self.raw {
             Ok(raw.clone())
         } else if let Some(node) = &self.node {
-            //let encoded = Box::<dyn Codec>::from(self.codec)
-            //    .encode(&node)
-            //    .unwrap()
-            //    .to_vec();
             let encoded = self.codec.encode(&node).unwrap().to_vec();
             self.raw = Some(encoded.clone());
             Ok(encoded)
@@ -147,7 +142,6 @@ where
         if let Some(cid) = &self.cid {
             Ok(cid.clone())
         } else {
-            // TODO vmx 2020-01-31: should probably be `encodeUnsafe()`
             let hash = Box::<dyn MultihashDigest<H>>::from(self.hash_alg).digest(&self.encode()?);
             let cid = CidGeneric::new_v1(self.codec, hash);
             Ok(cid)
@@ -347,7 +341,6 @@ where
             let hash = if let Some(raw) = &self.raw {
                 hasher.digest(raw)
             } else {
-                // TODO vmx 2020-01-31: should probably be `encodeUnsafe()`
                 hasher.digest(&self.encode()?)
             };
             let cid = CidGeneric::new_v1(self.codec, hash);

--- a/src/block.rs
+++ b/src/block.rs
@@ -12,16 +12,16 @@ use thiserror::Error;
 /// Block API Error.
 #[derive(Error, Debug)]
 pub enum BlockError {
-    /// TDOO
+    /// Block cannot be decoded.
     #[error("Cannot decode block.")]
     DecodeError(String),
-    /// TDOO
+    /// Block cannot be encoded.
     #[error("Cannot encode block.")]
     EncodeError(String),
-    /// TDOO
+    /// Codec implementation not found.
     #[error("Cannot find codec implementation.")]
     CodecNotFound,
-    /// TDOO
+    /// Hash algorithm implementation not found.
     #[error("Cannot find hash algorithm implementation.")]
     HashAlgNotFound,
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,101 +1,359 @@
-//! Block validation
+//! Lazily encode/decode blocks.
 use crate::cid::CidGeneric;
-use crate::codec::{Codec, Decode, Encode, IpldCodec};
+use crate::codec::IpldCodec;
 use crate::encode_decode::EncodeDecodeIpld;
-use crate::error::{Error, Result};
 use crate::ipld::Ipld;
-use crate::multihash::{Code as HCode, MultihashDigest, Multihasher};
-use crate::MAX_BLOCK_SIZE;
+use crate::multihash::{Code as HCode, MultihashDigest};
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::fmt;
+use thiserror::Error;
 
-/// Block
-pub struct Block<C = IpldCodec, H = HCode>
-where
-    C: Into<u64> + TryFrom<u64> + Copy,
-    H: Into<u64> + TryFrom<u64> + Copy,
-{
-    /// Content identifier.
-    pub cid: CidGeneric<C, H>,
-    /// Binary data.
-    pub data: Box<[u8]>,
+/// Block API Error.
+#[derive(Error, Debug)]
+pub enum BlockError {
+    /// TDOO
+    #[error("Cannot decode block.")]
+    DecodeError,
+    /// TDOO
+    #[error("Cannot encode block.")]
+    EncodeError,
+    /// TDOO
+    #[error("Cannot find codec implementation.")]
+    CodecNotFound,
+    /// TDOO
+    #[error("Cannot find hash algorithm implementation.")]
+    HashAlgNotFound,
 }
 
-/// Encode a block.`
-pub fn encode<C, H, O, M, E>(e: &E) -> Result<Block<C, H>>
-where
-    O: Codec<C>,
-    M: Multihasher<H>,
-    E: Encode<O, C>,
-    C: Into<u64> + TryFrom<u64> + Copy,
-    H: Into<u64> + TryFrom<u64> + Copy,
-{
-    let mut data = Vec::new();
-    e.encode(&mut data)
-        .map_err(|e| Error::CodecError(Box::new(e)))?;
-    if data.len() > MAX_BLOCK_SIZE {
-        return Err(Error::BlockTooLarge(data.len()));
-    }
-    let hash = M::digest(&data);
-    let cid = CidGeneric::<C, H>::new_v1(O::CODE, hash);
-    Ok(Block {
-        cid,
-        data: data.into_boxed_slice(),
-    })
-}
+/// Concrete Block which uses the default code tables
+pub type Block = BlockGeneric<IpldCodec, HCode>;
 
-/// Raw decode.
+/// Concrete Block with referenced data which uses the default code tables
+pub type BlockRef<'a> = BlockRefGeneric<'a, IpldCodec, HCode>;
+
+/// A `BlockGeneric` is an IPLD object together with a CID. The data can be encoded and decoded.
 ///
-/// Useful for nested encodings when for example the data is encrypted.
-pub fn raw_decode<C, H, O, D>(codec: C, mut data: &[u8]) -> Result<D>
+/// All operations are cached. This means that encoding, decoding and CID calculation happens
+/// at most once. All subsequent calls will use a cached version.
+pub struct BlockGeneric<C, H>
 where
-    O: Codec<C>,
-    D: Decode<O, C>,
-    C: Into<u64> + TryFrom<u64> + Copy + PartialEq,
-    H: Into<u64> + TryFrom<u64> + Copy,
+    C: Copy + TryFrom<u64> + Into<u64> + EncodeDecodeIpld<H>,
+    H: Copy + TryFrom<u64> + Into<u64>,
 {
-    if codec != O::CODE {
-        return Err(Error::UnsupportedCodec(codec.into()));
-    }
-    D::decode(&mut data).map_err(|e| Error::CodecError(Box::new(e)))
+    cid: Option<CidGeneric<C, H>>,
+    raw: Option<Vec<u8>>,
+    node: Option<Ipld<C, H>>,
+    codec: C,
+    hash_alg: H,
 }
 
-/// Decodes a block.
-pub fn decode<C, H, O, D>(cid: &CidGeneric<C, H>, data: &[u8]) -> Result<D>
+impl<C, H> BlockGeneric<C, H>
 where
-    O: Codec<C>,
-    D: Decode<O, C>,
-    C: Into<u64> + TryFrom<u64> + Copy + PartialEq,
-    H: Into<u64> + TryFrom<u64> + Copy + PartialEq,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    C: Copy + TryFrom<u64> + Into<u64> + EncodeDecodeIpld<H>,
+    H: Copy + TryFrom<u64> + Into<u64>,
 {
-    if data.len() > MAX_BLOCK_SIZE {
-        return Err(Error::BlockTooLarge(data.len()));
+    /// Create a new `Block` from the given CID and raw binary data.
+    ///
+    /// It needs a registry that contains codec and hash algorithms implementations in order to
+    /// be able to decode the data into IPLD.
+    pub fn new(cid: CidGeneric<C, H>, raw: Vec<u8>) -> Self {
+        let codec = cid.codec();
+        let hash_alg = cid.hash().algorithm();
+        Self {
+            cid: Some(cid),
+            raw: Some(raw),
+            node: None,
+            codec,
+            hash_alg,
+        }
     }
-    let hash = Box::<dyn MultihashDigest<H>>::from(cid.hash().algorithm()).digest(&data);
-    if hash.as_ref() != cid.hash() {
-        return Err(Error::InvalidHash(hash.to_vec()));
+
+    /// Create a new `Block` from the given IPLD object, codec and hash algorithm.
+    ///
+    /// No computation is done, the CID creation and the encoding will only be performed when the
+    /// corresponding methods are called.
+    pub fn encoder(node: Ipld<C, H>, codec: C, hash_alg: H) -> Self {
+        Self {
+            cid: None,
+            raw: None,
+            node: Some(node),
+            codec,
+            hash_alg,
+        }
     }
-    raw_decode::<C, H, O, D>(cid.codec(), data)
+
+    /// Create a new `Block` from encoded data, codec and hash algorithm.
+    ///
+    /// No computation is done, the CID creation and the decoding will only be performed when the
+    /// corresponding methods are called.
+    pub fn decoder(raw: Vec<u8>, codec: C, hash_alg: H) -> Self {
+        Self {
+            cid: None,
+            raw: Some(raw),
+            node: None,
+            codec,
+            hash_alg,
+        }
+    }
+
+    /// Decode the `Block` into an IPLD object.
+    ///
+    /// The actual decoding is only performed if the object doesn't have a copy of the IPLD
+    /// object yet. If that method was called before, it returns the cached result.
+    pub fn decode(&mut self) -> Result<Ipld<C, H>, BlockError> {
+        if let Some(node) = &self.node {
+            Ok(node.clone())
+        } else if let Some(raw) = &self.raw {
+            //let decoded = Box::<dyn DynIpldCodec>::from(Box::new(self.codec))._decode(&raw).unwrap();
+            let decoded = self.codec.decode(&raw).unwrap();
+            self.node = Some(decoded.clone());
+            Ok(decoded)
+        } else {
+            Err(BlockError::DecodeError)
+        }
+    }
+
+    /// Encode the `Block` into raw binary data.
+    ///
+    /// The actual encoding is only performed if the object doesn't have a copy of the encoded
+    /// raw binary data yet. If that method was called before, it returns the cached result.
+    pub fn encode(&mut self) -> Result<Vec<u8>, BlockError> {
+        if let Some(raw) = &self.raw {
+            Ok(raw.clone())
+        } else if let Some(node) = &self.node {
+            //let encoded = Box::<dyn Codec>::from(self.codec)
+            //    .encode(&node)
+            //    .unwrap()
+            //    .to_vec();
+            let encoded = self.codec.encode(&node).unwrap().to_vec();
+            self.raw = Some(encoded.clone());
+            Ok(encoded)
+        } else {
+            Err(BlockError::EncodeError)
+        }
+    }
+
+    /// Calculate the CID of the `Block`.
+    ///
+    /// The CID is calculated from the encoded data. If it wasn't encoded before, that
+    /// operation will be performed. If the encoded data is already available, from a previous
+    /// call of `encode()` or because the `Block` was instantiated via `encoder()`, then it
+    /// isn't re-encoded.
+    pub fn cid(&mut self) -> Result<CidGeneric<C, H>, BlockError>
+    where
+        Box<dyn MultihashDigest<H>>: From<H>,
+    {
+        if let Some(cid) = &self.cid {
+            Ok(cid.clone())
+        } else {
+            // TODO vmx 2020-01-31: should probably be `encodeUnsafe()`
+            let hash = Box::<dyn MultihashDigest<H>>::from(self.hash_alg).digest(&self.encode()?);
+            let cid = CidGeneric::new_v1(self.codec, hash);
+            Ok(cid)
+        }
+    }
 }
 
-/// Decode block to ipld.
-pub fn decode_ipld<C, H>(cid: &CidGeneric<C, H>, data: &[u8]) -> Result<Ipld<C, H>>
+impl<C, H> fmt::Debug for BlockGeneric<C, H>
 where
-    C: Into<u64> + TryFrom<u64> + Copy + PartialEq + EncodeDecodeIpld<H>,
-    H: Into<u64> + TryFrom<u64> + Copy + PartialEq,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    C: Copy + TryFrom<u64> + Into<u64> + fmt::Debug + EncodeDecodeIpld<H>,
+    H: Copy + TryFrom<u64> + Into<u64> + fmt::Debug,
+    H: Into<Box<dyn MultihashDigest<H>>>,
+    <C as TryFrom<u64>>::Error: fmt::Debug,
+    <H as TryFrom<u64>>::Error: fmt::Debug,
 {
-    if data.len() > MAX_BLOCK_SIZE {
-        return Err(Error::BlockTooLarge(data.len()));
+    fn fmt(&self, ff: &mut fmt::Formatter) -> fmt::Result {
+        write!(ff, "Block {{ cid: {:?}, raw: {:?} }}", self.cid, self.raw)
     }
-    let hash = Box::<dyn MultihashDigest<H>>::from(cid.hash().algorithm()).digest(&data);
-    if hash.as_ref() != cid.hash() {
-        return Err(Error::InvalidHash(hash.to_vec()));
+}
+
+/// A `BlockRefGeneric` is an IPLD object together with a CID. The data can be encoded and decoded.
+///
+/// The `BlockRefGeneric` is very similar to the [`BlockGeneric`]. The difference is that it
+/// doesn't own the data, but holds references only. When encoding/decoding of data is performed,
+/// then the result is cached.
+///
+/// # Example
+///
+/// You want to get the CID from already encoded data. There no additional encoding will happen,
+/// as we already have the data correctly encoded.
+///
+/// ```
+/// use libipld::block::BlockRef;
+/// use libipld::codec::IpldCodec;
+/// use libipld::multihash::Code;
+///
+/// let encoded = &[0x11, 0x22];
+/// let mut block = BlockRef::decoder(encoded, IpldCodec::Raw, Code::Sha2_256);
+/// let cid = block.cid().unwrap();
+/// ```
+///
+/// Additional encoding will happen in the following case, as only the decoded data is stored.
+///
+/// ```
+/// use libipld::block::BlockRef;
+/// use libipld::codec::IpldCodec;
+/// use libipld::ipld::Ipld;
+/// use libipld::multihash::Code;
+///
+/// let ipld = Ipld::Bool(true);
+/// let mut block = BlockRef::encoder(&ipld, IpldCodec::DagCbor, Code::Sha2_256);
+/// let cid = block.cid().unwrap();
+/// // This call will return the cached CID as we already did create it once.
+/// let cid2 = block.cid().unwrap();
+/// ```
+pub struct BlockRefGeneric<'a, C, H>
+where
+    C: Copy + TryFrom<u64> + Into<u64> + EncodeDecodeIpld<H>,
+    H: Copy + TryFrom<u64> + Into<u64>,
+{
+    cid: Option<&'a CidGeneric<C, H>>,
+    raw: Option<&'a [u8]>,
+    node: Option<&'a Ipld<C, H>>,
+    codec: C,
+    hash_alg: H,
+    cid_cached: Option<CidGeneric<C, H>>,
+    raw_cached: Option<Vec<u8>>,
+    node_cached: Option<Ipld<C, H>>,
+}
+
+impl<'a, C, H> BlockRefGeneric<'a, C, H>
+where
+    C: Copy + TryFrom<u64> + Into<u64> + EncodeDecodeIpld<H>,
+    H: Copy + TryFrom<u64> + Into<u64>,
+{
+    /// Create a new `Block` from the given CID and raw binary data.
+    ///
+    /// It needs a registry that contains codec and hash algorithms implementations in order to
+    /// be able to decode the data into IPLD.
+    pub fn new(cid: &'a CidGeneric<C, H>, raw: &'a [u8]) -> Self {
+        let codec = cid.codec();
+        let hash_alg = cid.hash().algorithm();
+        Self {
+            cid: Some(cid),
+            raw: Some(raw),
+            node: None,
+            codec,
+            hash_alg,
+            cid_cached: None,
+            raw_cached: None,
+            node_cached: None,
+        }
     }
-    cid.codec()
-        .decode(data)
-        .map_err(|e| Error::CodecError(Box::new(e)))
+
+    /// Create a new `Block` from the given IPLD object, codec and hash algorithm.
+    ///
+    /// No computation is done, the CID creation and the encoding will only be performed when the
+    /// corresponding methods are called.
+    pub fn encoder(node: &'a Ipld<C, H>, codec: C, hash_alg: H) -> Self {
+        Self {
+            cid: None,
+            raw: None,
+            node: Some(node),
+            codec,
+            hash_alg,
+            cid_cached: None,
+            raw_cached: None,
+            node_cached: None,
+        }
+    }
+
+    /// Create a new `Block` from encoded data, codec and hash algorithm.
+    ///
+    /// No computation is done, the CID creation and the decoding will only be performed when the
+    /// corresponding methods are called.
+    pub fn decoder(raw: &'a [u8], codec: C, hash_alg: H) -> Self {
+        Self {
+            cid: None,
+            raw: Some(raw),
+            node: None,
+            codec,
+            hash_alg,
+            cid_cached: None,
+            raw_cached: None,
+            node_cached: None,
+        }
+    }
+
+    /// Decode the `Block` into an IPLD object.
+    ///
+    /// The actual decoding is only performed if the object doesn't have a copy of the IPLD
+    /// object yet. If that method was called before, it returns the cached result.
+    pub fn decode(&mut self) -> Result<Ipld<C, H>, BlockError> {
+        // The block was constructed with a decdoded data
+        if let Some(node) = &self.node {
+            Ok((*node).clone())
+        }
+        // The decoder was already called at least once
+        else if let Some(node_cached) = &self.node_cached {
+            Ok(node_cached.clone())
+        }
+        // The data needs to be decoded
+        else if let Some(raw) = &self.raw {
+            let decoded = self.codec.decode(&raw).unwrap();
+            self.node_cached = Some(decoded.clone());
+            Ok(decoded)
+        } else {
+            Err(BlockError::DecodeError)
+        }
+    }
+
+    /// Encode the `Block` into raw binary data.
+    ///
+    /// The actual encoding is only performed if the object doesn't have a copy of the encoded
+    /// raw binary data yet. If that method was called before, it returns the cached result.
+    pub fn encode(&mut self) -> Result<Vec<u8>, BlockError> {
+        // The block was constructed with an encoded data
+        if let Some(raw) = &self.raw {
+            Ok(raw.to_vec())
+        }
+        // The encoder was already called at least once
+        else if let Some(raw_cached) = &self.raw_cached {
+            Ok(raw_cached.clone())
+        }
+        // The data needs to be decoded
+        else if let Some(node) = &self.node {
+            let encoded = self.codec.encode(&node).unwrap().to_vec();
+            self.raw_cached = Some(encoded.clone());
+            Ok(encoded)
+        } else {
+            Err(BlockError::EncodeError)
+        }
+    }
+
+    /// Calculate the CID of the `Block`.
+    ///
+    /// The CID is calculated from the encoded data. If it wasn't encoded before, that
+    /// operation will be performed. If the encoded data is already available, from a previous
+    /// call of `encode()` or because the `Block` was instantiated via `encoder()`, then it
+    /// isn't re-encoded.
+    pub fn cid(&mut self) -> Result<CidGeneric<C, H>, BlockError>
+    where
+        Box<dyn MultihashDigest<H>>: From<H>,
+    {
+        // The block was constructed with a CID
+        if let Some(cid) = &self.cid {
+            Ok((*cid).clone())
+        }
+        // The CID was already calculated at leat once
+        else if let Some(cid_cached) = &self.cid_cached {
+            Ok(cid_cached.clone())
+        }
+        // The CID needs to be calculated
+        else {
+            let hasher = Box::<dyn MultihashDigest<H>>::from(self.hash_alg);
+            // We already have the encoded data, use that one directly
+            let hash = if let Some(raw) = &self.raw {
+                hasher.digest(raw)
+            } else {
+                // TODO vmx 2020-01-31: should probably be `encodeUnsafe()`
+                hasher.digest(&self.encode()?)
+            };
+            let cid = CidGeneric::new_v1(self.codec, hash);
+            Ok(cid)
+        }
+    }
 }
 
 /// Returns the references in an ipld block.
@@ -117,6 +375,7 @@ where
 mod tests {
     use super::*;
     use crate::codec::Cid;
+    use crate::codec::IpldCodec;
     use crate::ipld;
     use crate::multihash::Sha2_256;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -18,12 +18,6 @@ pub enum BlockError {
     /// Block cannot be encoded.
     #[error("Cannot encode block.")]
     EncodeError(String),
-    /// Codec implementation not found.
-    #[error("Cannot find codec implementation.")]
-    CodecNotFound,
-    /// Hash algorithm implementation not found.
-    #[error("Cannot find hash algorithm implementation.")]
-    HashAlgNotFound,
 }
 
 /// Concrete Block which uses the default code tables

--- a/src/block.rs
+++ b/src/block.rs
@@ -109,9 +109,8 @@ where
             self.node = Some(decoded);
             Ok(self.node.as_ref().unwrap())
         } else {
-            Err(BlockError::DecodeError(
-                "Block is missing data.".to_string(),
-            ))
+            // All existing contructors make sure that eithe `self.node` or `self.raw` is set.
+            unreachable!()
         }
     }
 
@@ -130,7 +129,8 @@ where
             self.raw = Some(encoded);
             Ok(self.raw.as_ref().unwrap())
         } else {
-            Err(BlockError::EncodeError("Block is missing data".to_string()))
+            // All existing contructors make sure that eithe `self.node` or `self.raw` is set.
+            unreachable!()
         }
     }
 
@@ -296,9 +296,8 @@ where
             self.node_cached = Some(decoded);
             Ok(self.node_cached.as_ref().unwrap())
         } else {
-            Err(BlockError::DecodeError(
-                "Block is missing data.".to_string(),
-            ))
+            // All existing contructors make sure that eithe `self.node` or `self.raw` is set.
+            unreachable!()
         }
     }
 
@@ -324,7 +323,8 @@ where
             self.raw_cached = Some(encoded);
             Ok(self.raw_cached.as_ref().unwrap())
         } else {
-            Err(BlockError::EncodeError("Block is missing data".to_string()))
+            // All existing contructors make sure that eithe `self.node` or `self.raw` is set.
+            unreachable!()
         }
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -14,10 +14,10 @@ use thiserror::Error;
 pub enum BlockError {
     /// TDOO
     #[error("Cannot decode block.")]
-    DecodeError,
+    DecodeError(String),
     /// TDOO
     #[error("Cannot encode block.")]
-    EncodeError,
+    EncodeError(String),
     /// TDOO
     #[error("Cannot find codec implementation.")]
     CodecNotFound,
@@ -105,11 +105,16 @@ where
         if let Some(ref node) = self.node {
             Ok(node)
         } else if let Some(ref raw) = self.raw {
-            let decoded = self.codec.decode(raw).unwrap();
+            let decoded = self
+                .codec
+                .decode(raw)
+                .map_err(|err| BlockError::DecodeError(err.to_string()))?;
             self.node = Some(decoded);
             Ok(self.node.as_ref().unwrap())
         } else {
-            Err(BlockError::DecodeError)
+            Err(BlockError::DecodeError(
+                "Block is missing data.".to_string(),
+            ))
         }
     }
 
@@ -121,11 +126,15 @@ where
         if let Some(ref raw) = self.raw {
             Ok(raw)
         } else if let Some(ref node) = self.node {
-            let encoded = self.codec.encode(node).unwrap().to_vec();
+            let encoded = self
+                .codec
+                .encode(node)
+                .map_err(|err| BlockError::EncodeError(err.to_string()))?
+                .to_vec();
             self.raw = Some(encoded);
             Ok(self.raw.as_ref().unwrap())
         } else {
-            Err(BlockError::EncodeError)
+            Err(BlockError::EncodeError("Block is missing data".to_string()))
         }
     }
 
@@ -285,11 +294,16 @@ where
         }
         // The data needs to be decoded
         else if let Some(ref raw) = self.raw {
-            let decoded = self.codec.decode(raw).unwrap();
+            let decoded = self
+                .codec
+                .decode(raw)
+                .map_err(|err| BlockError::DecodeError(err.to_string()))?;
             self.node_cached = Some(decoded);
             Ok(self.node_cached.as_ref().unwrap())
         } else {
-            Err(BlockError::DecodeError)
+            Err(BlockError::DecodeError(
+                "Block is missing data.".to_string(),
+            ))
         }
     }
 
@@ -308,11 +322,15 @@ where
         }
         // The data needs to be decoded
         else if let Some(ref node) = self.node {
-            let encoded = self.codec.encode(node).unwrap().to_vec();
+            let encoded = self
+                .codec
+                .encode(node)
+                .map_err(|err| BlockError::EncodeError(err.to_string()))?
+                .to_vec();
             self.raw_cached = Some(encoded);
             Ok(self.raw_cached.as_ref().unwrap())
         } else {
-            Err(BlockError::EncodeError)
+            Err(BlockError::EncodeError("Block is missing data".to_string()))
         }
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -42,7 +42,7 @@ where
     H: Copy + TryFrom<u64> + Into<u64>,
 {
     cid: Option<CidGeneric<C, H>>,
-    raw: Option<Vec<u8>>,
+    raw: Option<Box<[u8]>>,
     node: Option<Ipld<C, H>>,
     codec: C,
     hash_alg: H,
@@ -57,7 +57,7 @@ where
     ///
     /// It needs a registry that contains codec and hash algorithms implementations in order to
     /// be able to decode the data into IPLD.
-    pub fn new(cid: CidGeneric<C, H>, raw: Vec<u8>) -> Self {
+    pub fn new(cid: CidGeneric<C, H>, raw: Box<[u8]>) -> Self {
         let codec = cid.codec();
         let hash_alg = cid.hash().algorithm();
         Self {
@@ -87,7 +87,7 @@ where
     ///
     /// No computation is done, the CID creation and the decoding will only be performed when the
     /// corresponding methods are called.
-    pub fn decoder(raw: Vec<u8>, codec: C, hash_alg: H) -> Self {
+    pub fn decoder(raw: Box<[u8]>, codec: C, hash_alg: H) -> Self {
         Self {
             cid: None,
             raw: Some(raw),
@@ -129,8 +129,7 @@ where
             let encoded = self
                 .codec
                 .encode(node)
-                .map_err(|err| BlockError::EncodeError(err.to_string()))?
-                .to_vec();
+                .map_err(|err| BlockError::EncodeError(err.to_string()))?;
             self.raw = Some(encoded);
             Ok(self.raw.as_ref().unwrap())
         } else {
@@ -217,7 +216,7 @@ where
     codec: C,
     hash_alg: H,
     cid_cached: Option<CidGeneric<C, H>>,
-    raw_cached: Option<Vec<u8>>,
+    raw_cached: Option<Box<[u8]>>,
     node_cached: Option<Ipld<C, H>>,
 }
 
@@ -325,8 +324,7 @@ where
             let encoded = self
                 .codec
                 .encode(node)
-                .map_err(|err| BlockError::EncodeError(err.to_string()))?
-                .to_vec();
+                .map_err(|err| BlockError::EncodeError(err.to_string()))?;
             self.raw_cached = Some(encoded);
             Ok(self.raw_cached.as_ref().unwrap())
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 //! `Ipld` error definitions.
+use crate::block::BlockError;
 pub use libipld_core::error::*;
 use thiserror::Error;
 
@@ -47,4 +48,7 @@ pub enum StoreError {
     /// Other failure.
     #[error("{0}")]
     Other(#[from] Box<dyn std::error::Error + Send>),
+    /// Block API encoding/decoding errors.
+    #[error("Block encoding/decoding failed: {0}")]
+    BlockApi(#[from] BlockError),
 }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -3,7 +3,7 @@ use crate::block::{BlockGeneric, BlockRefGeneric};
 use crate::cid::CidGeneric;
 use crate::encode_decode::EncodeDecodeIpld;
 use crate::error::StoreError;
-use crate::multihash::MultihashDigest;
+use crate::multihash::DigestFromCode;
 use crate::store::{AliasStore, ReadonlyStore, Store, StoreResult, Visibility};
 use async_std::sync::{Arc, RwLock};
 use std::collections::{HashMap, HashSet};
@@ -24,8 +24,7 @@ where
 impl<C, H> InnerStore<C, H>
 where
     C: Into<u64> + TryFrom<u64> + Copy + Eq + EncodeDecodeIpld<H>,
-    H: Into<u64> + TryFrom<u64> + Copy + Eq,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    H: Into<u64> + TryFrom<u64> + Copy + Eq + DigestFromCode,
 {
     /// Create a new empty `InnerStore`
     pub fn new() -> Self {
@@ -133,8 +132,7 @@ where
 impl<C, H> MemStore<C, H>
 where
     C: Into<u64> + TryFrom<u64> + Copy + Eq + EncodeDecodeIpld<H>,
-    H: Into<u64> + TryFrom<u64> + Copy + Eq,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    H: Into<u64> + TryFrom<u64> + Copy + Eq + DigestFromCode,
 {
     /// Create a new empty `MemStore`
     pub fn new() -> Self {
@@ -148,8 +146,7 @@ where
 impl<C, H> ReadonlyStore<C, H> for MemStore<C, H>
 where
     C: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync + EncodeDecodeIpld<H>,
-    H: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    H: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync + DigestFromCode,
 {
     fn get<'a>(&'a self, cid: &'a CidGeneric<C, H>) -> StoreResult<'a, Box<[u8]>> {
         Box::pin(async move { self.inner.read().await.get(cid) })
@@ -159,8 +156,7 @@ where
 impl<C, H> Store<C, H> for MemStore<C, H>
 where
     C: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync + EncodeDecodeIpld<H>,
-    H: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync,
-    Box<dyn MultihashDigest<H>>: From<H>,
+    H: Into<u64> + TryFrom<u64> + Copy + Eq + Send + Sync + DigestFromCode,
 {
     fn insert<'a>(
         &'a self,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,8 @@
 //! Store traits.
-use crate::block::Block;
+use crate::block::BlockGeneric;
 use crate::cid::CidGeneric;
 use crate::codec::IpldCodec;
+use crate::encode_decode::EncodeDecodeIpld;
 use crate::error::StoreError;
 use crate::multihash::Code as MultihashCode;
 use core::future::Future;
@@ -24,7 +25,7 @@ pub enum Visibility {
 /// Implementable by ipld storage providers.
 pub trait ReadonlyStore<C = IpldCodec, H = MultihashCode>: Clone
 where
-    C: Into<u64> + TryFrom<u64> + Copy,
+    C: Into<u64> + TryFrom<u64> + Copy + EncodeDecodeIpld<H>,
     H: Into<u64> + TryFrom<u64> + Copy,
 {
     /// Returns a block from the store. If the block is not in the store it fetches it from the
@@ -35,7 +36,7 @@ where
 /// Implementable by ipld storage backends.
 pub trait Store<C = IpldCodec, H = MultihashCode>: ReadonlyStore<C, H>
 where
-    C: Into<u64> + TryFrom<u64> + Copy,
+    C: Into<u64> + TryFrom<u64> + Copy + EncodeDecodeIpld<H>,
     H: Into<u64> + TryFrom<u64> + Copy,
 {
     /// Inserts and pins block into the store and announces it if it is visible.
@@ -50,7 +51,7 @@ where
     /// if it is visible. The last block is pinned.
     fn insert_batch<'a>(
         &'a self,
-        batch: Vec<Block<C, H>>,
+        batch: Vec<BlockGeneric<C, H>>,
         visibility: Visibility,
     ) -> StoreResult<'a, CidGeneric<C, H>>;
 
@@ -64,7 +65,7 @@ where
 /// Implemented by ipld storage backends that support multiple users.
 pub trait MultiUserStore<C, H>: Store<C, H>
 where
-    C: Into<u64> + TryFrom<u64> + Copy,
+    C: Into<u64> + TryFrom<u64> + Copy + EncodeDecodeIpld<H>,
     H: Into<u64> + TryFrom<u64> + Copy,
 {
     /// Pin a block.


### PR DESCRIPTION
This commit adds a new Block API. Encoding/decoding only happens when
it is needed. Once such an expensive operation was done, the result
is cached, so that subsequent calls can just return the result.

---

This PR isn't meant as "this should be merged exactly like this". This is meant as a starting point for further discussions. So far when I was talking about the Block API (https://github.com/ipfs-rust/rust-ipld/issues/14), things were pretty abstract, I hope that with this PR things become more concrete. This should illustrate what I'm after. Though getting there could also look completely different.

What I'd like to see that those `Block`s become a integral part, which then e.g. also the storage traits are using.

I know that @dvc94ch use cases are different from mine, so I hope we can find
solutions to both our use cases.

---

One more specific note, I'm not sure if the caching should be implemented for `BlockRef`, it might be nicer/work good enough without it.