### PR TITLE
Make Store generic, to enable downstream impl of Store trait that don't have to serialise

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -15,11 +15,11 @@ use libipld_pb::DagPbCodec;
 use std::collections::HashSet;
 
 /// Block
-pub struct Block {
+pub struct Block<T = Box<[u8]>> {
     /// Content identifier.
     pub cid: Cid,
     /// Binary data.
-    pub data: Box<[u8]>,
+    pub data: T,
 }
 
 /// Encode a block.

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -101,19 +101,16 @@ pub struct MemStore {
     aliases: Arc<RwLock<HashMap<Box<[u8]>, Cid>>>,
 }
 
-impl ReadonlyStore for MemStore {
+impl ReadonlyStore for MemStore
+{
     fn get<'a>(&'a self, cid: &'a Cid) -> StoreResult<'a, Box<[u8]>> {
         Box::pin(async move { self.inner.read().await.get(cid) })
     }
 }
 
-impl Store for MemStore {
-    fn insert<'a>(
-        &'a self,
-        cid: &'a Cid,
-        data: Box<[u8]>,
-        _visibility: Visibility,
-    ) -> StoreResult<'a, ()> {
+impl Store for MemStore
+{
+    fn insert<'a>(&'a self, cid: &'a Cid, data: Box<[u8]>, _visibility: Visibility) -> StoreResult<'a, ()> {
         Box::pin(async move { self.inner.write().await.insert(cid, data) })
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -19,29 +19,30 @@ pub enum Visibility {
 }
 
 /// Implementable by ipld storage providers.
-pub trait ReadonlyStore: Clone {
+pub trait ReadonlyStore<T = Box<[u8]>>: Clone
+where
+    T: Clone,
+{
     /// Returns a block from the store. If the block is not in the
     /// store it fetches it from the network and pins the block. This
     /// future should be wrapped in a timeout. Dropping the future
     /// cancels the request.
-    fn get<'a>(&'a self, cid: &'a Cid) -> StoreResult<'a, Box<[u8]>>;
+    fn get<'a>(&'a self, cid: &'a Cid) -> StoreResult<'a, T>;
 }
 
 /// Implementable by ipld storage backends.
-pub trait Store: ReadonlyStore {
+pub trait Store<T = Box<[u8]>>: ReadonlyStore<T>
+where
+    T: Clone,
+{
     /// Inserts and pins block into the store and announces it if it is visible.
-    fn insert<'a>(
-        &'a self,
-        cid: &'a Cid,
-        data: Box<[u8]>,
-        visibility: Visibility,
-    ) -> StoreResult<'a, ()>;
+    fn insert<'a>(&'a self, cid: &'a Cid, data: T, visibility: Visibility) -> StoreResult<'a, ()>;
 
     /// Inserts a batch of blocks atomically into the store and announces them block
     /// if it is visible. The last block is pinned.
     fn insert_batch<'a>(
         &'a self,
-        batch: Vec<Block>,
+        batch: Vec<Block<T>>,
         visibility: Visibility,
     ) -> StoreResult<'a, Cid>;
 


### PR DESCRIPTION
The main use case for this is having a store implementation that is useful for debugging. The current Store trait forces to serialise, and leads to unhelpful Debug impl.

This can't be merged since it's based of the 0.3.0 release a few commits back, but is meant as RFC.