### PR TITLE
feat: remove `decode_ipld()`

### DIFF
--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -1,6 +1,5 @@
 //! `Ipld` codecs.
 use crate::error::{Result, UnsupportedCodec};
-use crate::ipld::Ipld;
 use crate::MAX_BLOCK_SIZE;
 use core::convert::TryFrom;
 use std::io::{Read, Write};
@@ -20,9 +19,6 @@ pub trait Codec:
     fn decode<T: Decode<Self>>(&self, mut bytes: &[u8]) -> Result<T> {
         T::decode(*self, &mut bytes)
     }
-
-    /// Decode ipld.
-    fn decode_ipld(&self, bytes: &[u8]) -> Result<Ipld>;
 }
 
 /// Encode trait.
@@ -50,11 +46,7 @@ mod tests {
     #[derive(Clone, Copy, Debug)]
     struct CodecImpl;
 
-    impl Codec for CodecImpl {
-        fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-            Ipld::decode(*self, &mut bytes)
-        }
-    }
+    impl Codec for CodecImpl {}
 
     impl From<CodecImpl> for u64 {
         fn from(_: CodecImpl) -> Self {

--- a/core/src/raw.rs
+++ b/core/src/raw.rs
@@ -9,11 +9,7 @@ use std::io::{Read, Write};
 #[derive(Clone, Copy, Debug)]
 pub struct RawCodec;
 
-impl Codec for RawCodec {
-    fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-        Ipld::decode(*self, &mut bytes)
-    }
-}
+impl Codec for RawCodec {}
 
 impl From<RawCodec> for u64 {
     fn from(_: RawCodec) -> Self {

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -5,7 +5,6 @@
 use core::convert::TryFrom;
 use libipld_core::codec::{Codec, Decode, Encode};
 pub use libipld_core::error::{Result, UnsupportedCodec};
-use libipld_core::ipld::Ipld;
 
 pub mod decode;
 pub mod encode;
@@ -15,11 +14,7 @@ pub mod error;
 #[derive(Clone, Copy, Debug)]
 pub struct DagCborCodec;
 
-impl Codec for DagCborCodec {
-    fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-        Ipld::decode(*self, &mut bytes)
-    }
-}
+impl Codec for DagCborCodec {}
 
 impl From<DagCborCodec> for u64 {
     fn from(_: DagCborCodec) -> Self {

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -16,11 +16,7 @@ mod codec;
 #[derive(Clone, Copy, Debug)]
 pub struct DagJsonCodec;
 
-impl Codec for DagJsonCodec {
-    fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-        Ipld::decode(*self, &mut bytes)
-    }
-}
+impl Codec for DagJsonCodec {}
 
 impl From<DagJsonCodec> for u64 {
     fn from(_: DagJsonCodec) -> Self {

--- a/dag-pb/src/lib.rs
+++ b/dag-pb/src/lib.rs
@@ -15,11 +15,7 @@ mod codec;
 #[derive(Clone, Copy, Debug)]
 pub struct DagPbCodec;
 
-impl Codec for DagPbCodec {
-    fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-        Ipld::decode(*self, &mut bytes)
-    }
-}
+impl Codec for DagPbCodec {}
 
 impl From<DagPbCodec> for u64 {
     fn from(_: DagPbCodec) -> Self {

--- a/src/block.rs
+++ b/src/block.rs
@@ -2,7 +2,6 @@
 use crate::cid::Cid;
 use crate::codec::{Codec, Decode, Encode};
 use crate::error::{InvalidMultihash, Result, UnsupportedMultihash};
-use crate::ipld::Ipld;
 use crate::multihash::MultihashDigest;
 use core::marker::PhantomData;
 
@@ -87,18 +86,30 @@ impl<C: Codec, M: MultihashDigest> Block<C, M> {
     }
 
     /// Decodes a block.
+    ///
+    /// # Example
+    ///
+    /// Decoding to [`Ipld`]:
+    ///
+    /// ```
+    /// use libipld::block::Block;
+    /// use libipld::cbor::DagCborCodec;
+    /// use libipld::codec_impl::Multicodec;
+    /// use libipld::ipld::Ipld;
+    /// use libipld::multihash::{Multihash, SHA2_256};
+    ///
+    /// let block =
+    ///     Block::<Multicodec, Multihash>::encode(DagCborCodec, SHA2_256, "Hello World!").unwrap();
+    /// let ipld = block.decode::<DagCborCodec, Ipld>().unwrap();
+    ///
+    /// assert_eq!(ipld, Ipld::String("Hello World!".to_string()));
+    /// ```
     pub fn decode<CD: Codec, T: Decode<CD>>(&self) -> Result<T>
     where
         C: Into<CD>,
     {
         verify_cid::<M>(&self.cid, &self.data)?;
         CD::try_from(self.cid.codec())?.decode(&self.data)
-    }
-
-    /// Decodes to ipld.
-    pub fn decode_ipld(&self) -> Result<Ipld> {
-        verify_cid::<M>(&self.cid, &self.data)?;
-        C::try_from(self.cid.codec())?.decode_ipld(&self.data)
     }
 }
 
@@ -109,6 +120,7 @@ mod tests {
     use crate::cid::DAG_CBOR;
     use crate::codec_impl::Multicodec;
     use crate::ipld;
+    use crate::ipld::Ipld;
     use crate::multihash::{Multihash, SHA2_256};
 
     type IpldBlock = Block<Multicodec, Multihash>;

--- a/src/codec_impl.rs
+++ b/src/codec_impl.rs
@@ -107,11 +107,7 @@ impl From<Multicodec> for DagPbCodec {
     }
 }
 
-impl Codec for Multicodec {
-    fn decode_ipld(&self, mut bytes: &[u8]) -> Result<Ipld> {
-        Ipld::decode(*self, &mut bytes)
-    }
-}
+impl Codec for Multicodec {}
 
 impl Encode<Multicodec> for Ipld {
     fn encode<W: Write>(&self, c: Multicodec, w: &mut W) -> Result<()> {


### PR DESCRIPTION
Instead of having a dedicated method to decode blocks that ever
codec needs to implement, use the `decode()` method.

I think those additional trait bounds are worth having a simpler,
more uniform API.