### PR TITLE
fix: rename `Multicodec` to `IpldCodec`

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -149,7 +149,6 @@ impl<S: StoreParams> Block<S> {
     /// ```
     /// use libipld::block::Block;
     /// use libipld::cbor::DagCborCodec;
-    /// use libipld::codec_impl::Multicodec;
     /// use libipld::ipld::Ipld;
     /// use libipld::multihash::Code;
     /// use libipld::store::DefaultParams;
@@ -194,7 +193,7 @@ mod tests {
     use super::*;
     use crate::cbor::DagCborCodec;
     use crate::cid::DAG_CBOR;
-    use crate::codec_impl::Multicodec;
+    use crate::codec_impl::IpldCodec;
     use crate::ipld;
     use crate::ipld::Ipld;
     use crate::multihash::Code;
@@ -204,11 +203,10 @@ mod tests {
 
     #[test]
     fn test_references() {
-        let b1 =
-            IpldBlock::encode(Multicodec::Raw, Code::Blake3_256, &ipld!(&b"cid1"[..])).unwrap();
-        let b2 = IpldBlock::encode(Multicodec::DagJson, Code::Blake3_256, &ipld!("cid2")).unwrap();
+        let b1 = IpldBlock::encode(IpldCodec::Raw, Code::Blake3_256, &ipld!(&b"cid1"[..])).unwrap();
+        let b2 = IpldBlock::encode(IpldCodec::DagJson, Code::Blake3_256, &ipld!("cid2")).unwrap();
         let b3 = IpldBlock::encode(
-            Multicodec::DagPb,
+            IpldCodec::DagPb,
             Code::Blake3_256,
             &ipld!({
                 "Data": &b"data"[..],
@@ -222,8 +220,8 @@ mod tests {
             "cid2": { "other": true, "cid2": { "cid2": &b2.cid }},
             "cid3": [[ &b3.cid, &b1.cid ]],
         });
-        let block = IpldBlock::encode(Multicodec::DagCbor, Code::Blake3_256, &payload).unwrap();
-        let payload2 = block.decode::<Multicodec, _>().unwrap();
+        let block = IpldBlock::encode(IpldCodec::DagCbor, Code::Blake3_256, &payload).unwrap();
+        let payload2 = block.decode::<IpldCodec, _>().unwrap();
         assert_eq!(payload, payload2);
 
         let refs = payload2.references();

--- a/src/codec_impl.rs
+++ b/src/codec_impl.rs
@@ -14,7 +14,7 @@ use std::io::{Read, Write};
 
 /// Default codecs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Multicodec {
+pub enum IpldCodec {
     /// Raw codec.
     Raw,
     /// Cbor codec.
@@ -28,7 +28,7 @@ pub enum Multicodec {
     DagPb,
 }
 
-impl TryFrom<u64> for Multicodec {
+impl TryFrom<u64> for IpldCodec {
     type Error = UnsupportedCodec;
 
     fn try_from(ccode: u64) -> core::result::Result<Self, Self::Error> {
@@ -45,95 +45,95 @@ impl TryFrom<u64> for Multicodec {
     }
 }
 
-impl From<Multicodec> for u64 {
-    fn from(mc: Multicodec) -> Self {
+impl From<IpldCodec> for u64 {
+    fn from(mc: IpldCodec) -> Self {
         match mc {
-            Multicodec::Raw => crate::cid::RAW,
+            IpldCodec::Raw => crate::cid::RAW,
             #[cfg(feature = "dag-cbor")]
-            Multicodec::DagCbor => crate::cid::DAG_CBOR,
+            IpldCodec::DagCbor => crate::cid::DAG_CBOR,
             #[cfg(feature = "dag-json")]
-            Multicodec::DagJson => crate::cid::DAG_JSON,
+            IpldCodec::DagJson => crate::cid::DAG_JSON,
             #[cfg(feature = "dag-pb")]
-            Multicodec::DagPb => crate::cid::DAG_PROTOBUF,
+            IpldCodec::DagPb => crate::cid::DAG_PROTOBUF,
         }
     }
 }
 
-impl From<RawCodec> for Multicodec {
+impl From<RawCodec> for IpldCodec {
     fn from(_: RawCodec) -> Self {
         Self::Raw
     }
 }
 
 #[cfg(feature = "dag-cbor")]
-impl From<DagCborCodec> for Multicodec {
+impl From<DagCborCodec> for IpldCodec {
     fn from(_: DagCborCodec) -> Self {
         Self::DagCbor
     }
 }
 
 #[cfg(feature = "dag-cbor")]
-impl From<Multicodec> for DagCborCodec {
-    fn from(_: Multicodec) -> Self {
+impl From<IpldCodec> for DagCborCodec {
+    fn from(_: IpldCodec) -> Self {
         Self
     }
 }
 
 #[cfg(feature = "dag-json")]
-impl From<DagJsonCodec> for Multicodec {
+impl From<DagJsonCodec> for IpldCodec {
     fn from(_: DagJsonCodec) -> Self {
         Self::DagJson
     }
 }
 
 #[cfg(feature = "dag-json")]
-impl From<Multicodec> for DagJsonCodec {
-    fn from(_: Multicodec) -> Self {
+impl From<IpldCodec> for DagJsonCodec {
+    fn from(_: IpldCodec) -> Self {
         Self
     }
 }
 
 #[cfg(feature = "dag-pb")]
-impl From<DagPbCodec> for Multicodec {
+impl From<DagPbCodec> for IpldCodec {
     fn from(_: DagPbCodec) -> Self {
         Self::DagPb
     }
 }
 
 #[cfg(feature = "dag-pb")]
-impl From<Multicodec> for DagPbCodec {
-    fn from(_: Multicodec) -> Self {
+impl From<IpldCodec> for DagPbCodec {
+    fn from(_: IpldCodec) -> Self {
         Self
     }
 }
 
-impl Codec for Multicodec {}
+impl Codec for IpldCodec {}
 
-impl Encode<Multicodec> for Ipld {
-    fn encode<W: Write>(&self, c: Multicodec, w: &mut W) -> Result<()> {
+impl Encode<IpldCodec> for Ipld {
+    fn encode<W: Write>(&self, c: IpldCodec, w: &mut W) -> Result<()> {
         match c {
-            Multicodec::Raw => self.encode(RawCodec, w)?,
+            IpldCodec::Raw => self.encode(RawCodec, w)?,
             #[cfg(feature = "dag-cbor")]
-            Multicodec::DagCbor => self.encode(DagCborCodec, w)?,
+            IpldCodec::DagCbor => self.encode(DagCborCodec, w)?,
             #[cfg(feature = "dag-json")]
-            Multicodec::DagJson => self.encode(DagJsonCodec, w)?,
+            IpldCodec::DagJson => self.encode(DagJsonCodec, w)?,
             #[cfg(feature = "dag-pb")]
-            Multicodec::DagPb => self.encode(DagPbCodec, w)?,
+            IpldCodec::DagPb => self.encode(DagPbCodec, w)?,
         };
         Ok(())
     }
 }
 
-impl Decode<Multicodec> for Ipld {
-    fn decode<R: Read>(c: Multicodec, r: &mut R) -> Result<Self> {
+impl Decode<IpldCodec> for Ipld {
+    fn decode<R: Read>(c: IpldCodec, r: &mut R) -> Result<Self> {
         Ok(match c {
-            Multicodec::Raw => Self::decode(RawCodec, r)?,
+            IpldCodec::Raw => Self::decode(RawCodec, r)?,
             #[cfg(feature = "dag-cbor")]
-            Multicodec::DagCbor => Self::decode(DagCborCodec, r)?,
+            IpldCodec::DagCbor => Self::decode(DagCborCodec, r)?,
             #[cfg(feature = "dag-json")]
-            Multicodec::DagJson => Self::decode(DagJsonCodec, r)?,
+            IpldCodec::DagJson => Self::decode(DagJsonCodec, r)?,
             #[cfg(feature = "dag-pb")]
-            Multicodec::DagPb => Self::decode(DagPbCodec, r)?,
+            IpldCodec::DagPb => Self::decode(DagPbCodec, r)?,
         })
     }
 }
@@ -145,14 +145,14 @@ mod tests {
     #[test]
     fn raw_encode() {
         let data = Ipld::Bytes([0x22, 0x33, 0x44].to_vec());
-        let result = Multicodec::Raw.encode(&data).unwrap();
+        let result = IpldCodec::Raw.encode(&data).unwrap();
         assert_eq!(result, vec![0x22, 0x33, 0x44]);
     }
 
     #[test]
     fn raw_decode() {
         let data = [0x22, 0x33, 0x44];
-        let result: Ipld = Multicodec::Raw.decode(&data).unwrap();
+        let result: Ipld = IpldCodec::Raw.decode(&data).unwrap();
         assert_eq!(result, Ipld::Bytes(data.to_vec()));
     }
 
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn dag_cbor_encode() {
         let data = Ipld::Bytes([0x22, 0x33, 0x44].to_vec());
-        let result = Multicodec::DagCbor.encode(&data).unwrap();
+        let result = IpldCodec::DagCbor.encode(&data).unwrap();
         assert_eq!(result, vec![0x43, 0x22, 0x33, 0x44]);
     }
 
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn dag_cbor_decode() {
         let data = [0x43, 0x22, 0x33, 0x44];
-        let result: Ipld = Multicodec::DagCbor.decode(&data).unwrap();
+        let result: Ipld = IpldCodec::DagCbor.decode(&data).unwrap();
         assert_eq!(result, Ipld::Bytes(vec![0x22, 0x33, 0x44]));
     }
 
@@ -176,8 +176,7 @@ mod tests {
     #[test]
     fn dag_json_encode() {
         let data = Ipld::Bool(true);
-        let result =
-            String::from_utf8(Multicodec::DagJson.encode(&data).unwrap().to_vec()).unwrap();
+        let result = String::from_utf8(IpldCodec::DagJson.encode(&data).unwrap().to_vec()).unwrap();
         assert_eq!(result, "true");
     }
 
@@ -185,7 +184,7 @@ mod tests {
     #[test]
     fn dag_json_decode() {
         let data = b"true";
-        let result: Ipld = Multicodec::DagJson.decode(data).unwrap();
+        let result: Ipld = IpldCodec::DagJson.decode(data).unwrap();
         assert_eq!(result, Ipld::Bool(true));
     }
 
@@ -197,7 +196,7 @@ mod tests {
         data_map.insert("Links".to_string(), Ipld::List(vec![]));
 
         let data = Ipld::Map(data_map);
-        let result = Multicodec::DagPb.encode(&data).unwrap();
+        let result = IpldCodec::DagPb.encode(&data).unwrap();
         assert_eq!(result, vec![0x0a, 0x04, 0x64, 0x61, 0x74, 0x61]);
     }
 
@@ -210,7 +209,7 @@ mod tests {
         let expected = Ipld::Map(data_map);
 
         let data = [0x0a, 0x04, 0x64, 0x61, 0x74, 0x61];
-        let result: Ipld = Multicodec::DagPb.decode(&data).unwrap();
+        let result: Ipld = IpldCodec::DagPb.decode(&data).unwrap();
         assert_eq!(result, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use libipld_pb as pb;
 
 pub use block::Block;
 pub use cid::Cid;
-pub use codec_impl::Multicodec;
+pub use codec_impl::IpldCodec;
 pub use ipld::Ipld;
 pub use multihash::Multihash;
 pub use path::{DagPath, Path};

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,7 +24,7 @@ pub struct DefaultParams;
 
 impl StoreParams for DefaultParams {
     const MAX_BLOCK_SIZE: usize = 1_048_576;
-    type Codecs = crate::Multicodec;
+    type Codecs = crate::IpldCodec;
     type Hashes = crate::multihash::Code;
 }
 


### PR DESCRIPTION
The word `Multicodec` describes a table of codes for all sorts of things.
It describes IPLD Codecs as well as Multihashes. The central enum of this
crate is about IPLD Codecs, hence `IpldCodec` is a better name.

BREAKING CHANGE: The `Multicodec` enum is now called `IpldCodec`.

Fixes #56.

I didn't expect a release to happen so soon. Hence I create this PR now, so
it can be integrated into the next breaking release.

