### PR TITLE
Add convenience instances for IgnoredAny and RawValue

### DIFF
--- a/core/src/raw_value.rs
+++ b/core/src/raw_value.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 /// A raw value for a certain codec.
 ///
 /// Contains the raw, unprocessed data for a single item for that particular codec
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RawValue<C> {
     data: Box<[u8]>,
     _p: PhantomData<C>,
@@ -72,6 +73,7 @@ impl<C: Codec> Encode<C> for RawValue<C> {
 }
 
 /// Allows to ignore a single item
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct IgnoredAny;
 
 impl<C: Codec + SkipOne> Decode<C> for IgnoredAny {

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -11,7 +11,7 @@ pub mod encode;
 pub mod error;
 
 /// CBOR codec.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DagCborCodec;
 
 impl Codec for DagCborCodec {}

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -14,7 +14,7 @@ use std::io::{Read, Seek, Write};
 mod codec;
 
 /// Json codec.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DagJsonCodec;
 
 impl Codec for DagJsonCodec {}

--- a/dag-pb/src/lib.rs
+++ b/dag-pb/src/lib.rs
@@ -13,7 +13,7 @@ use std::io::{Read, Seek, Write};
 mod codec;
 
 /// Protobuf codec.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DagPbCodec;
 
 impl Codec for DagPbCodec {}


### PR DESCRIPTION
Just so it is easier to use them in structs that derive the usual stuff.

Ended up also adding convenience instances for the codec zero size structs.