### PR TITLE
Nicer assert_roundtrip that produces hex

### DIFF
--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -83,11 +83,22 @@ where
     T: Decode<C> + Encode<C> + std::fmt::Debug + PartialEq,
     Ipld: Decode<C> + Encode<C>,
 {
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+    }
     let mut bytes = Vec::new();
     data.encode(c, &mut bytes).unwrap();
     let mut bytes2 = Vec::new();
     ipld.encode(c, &mut bytes2).unwrap();
-    assert_eq!(bytes, bytes2);
+    if bytes != bytes2 {
+        panic!(
+            r#"assertion failed: `(left == right)`
+        left: `{}`,
+       right: `{}`"#,
+            hex(&bytes),
+            hex(&bytes2)
+        );
+    }
     let ipld2: Ipld = Decode::decode(c, &mut Cursor::new(bytes.as_slice())).unwrap();
     assert_eq!(&ipld2, ipld);
     let data2: T = Decode::decode(c, &mut Cursor::new(bytes.as_slice())).unwrap();

--- a/dag-cbor/tests/roundtrip.rs
+++ b/dag-cbor/tests/roundtrip.rs
@@ -2,7 +2,7 @@ use libipld_cbor::DagCborCodec;
 use libipld_core::{
     cid::Cid,
     codec::References,
-    codec::{Codec, Decode},
+    codec::{assert_roundtrip, Codec, Decode},
     ipld::Ipld,
     raw_value::{IgnoredAny, RawValue, SkipOne},
 };
@@ -115,4 +115,10 @@ fn indefinite_length_refs() {
     );
     assert_eq!(refs.len(), 1);
     assert_eq!(r.position(), 48);
+}
+
+#[test]
+#[should_panic]
+fn test_assert_roundtrip() {
+    assert_roundtrip(DagCborCodec, &1u64, &Ipld::Integer(2));
 }


### PR DESCRIPTION
Basically I like to copy stuff into cbor.me when a test fails, and the standard debug output does not make that very easy...

The new output is identical to assert_eq, except in hex:

```
thread 'test_assert_roundtrip' panicked at 'assertion failed: `(left == right)`
        left: `8401020304`,
       right: `02`', /home/rklaehn/projects_git/libipld/core/src/codec.rs:94:9
```