### PR TITLE
fix encoding & decoding

### DIFF
--- a/dag-cbor-derive/src/gen.rs
+++ b/dag-cbor-derive/src/gen.rs
@@ -18,7 +18,8 @@ pub fn gen_encode(ast: &SchemaType) -> TokenStream {
                 w: &mut W,
             ) -> libipld::Result<()> {
                 use libipld::codec::Encode;
-                use libipld::cbor::encode::{write_null, write_u64};
+                use libipld::cbor::cbor::*;
+                use libipld::cbor::encode::{write_null, write_u8, write_u64};
                 #body
             }
         }
@@ -39,7 +40,8 @@ pub fn gen_decode(ast: &SchemaType) -> TokenStream {
                 c: libipld::cbor::DagCborCodec,
                 r: &mut R,
             ) -> libipld::Result<Self> {
-                use libipld::cbor::decode::{read_len, read_u8, read_u64};
+                use libipld::cbor::cbor::*;
+                use libipld::cbor::decode::{read_uint, read_major};
                 use libipld::cbor::error::{LengthOutOfRange, MissingKey, UnexpectedCode, UnexpectedKey};
                 use libipld::codec::Decode;
                 use libipld::error::Result;
@@ -121,7 +123,7 @@ fn gen_encode_struct_body(s: &Struct) -> TokenStream {
             quote! {
                 let mut len = #len;
                 #(#dfields)*
-                write_u64(w, 5, len)?;
+                write_u64(w, MajorKind::Map, len)?;
                 #(#fields)*
             }
         }
@@ -134,7 +136,7 @@ fn gen_encode_struct_body(s: &Struct) -> TokenStream {
                 }
             });
             quote! {
-                write_u64(w, 4, #len)?;
+                write_u64(w, MajorKind::Array, #len)?;
                 #(#fields)*
             }
         }
@@ -171,7 +173,7 @@ fn gen_encode_union(u: &Union) -> TokenStream {
                 UnionRepr::Keyed => {
                     quote! {
                         #pat => {
-                            write_u64(w, 5, 1)?;
+                            write_u8(w, MajorKind::Map, 1)?;
                             Encode::encode(#key, c, w)?;
                             #value
                         }
@@ -191,8 +193,8 @@ fn gen_encode_union(u: &Union) -> TokenStream {
                 UnionRepr::IntTuple => {
                     quote! {
                         #pat => {
-                            write_u64(w, 4, 2)?;
-                            write_u64(w, 0, #i as u64)?;
+                            write_u8(w, MajorKind::Array, 2)?;
+                            write_u64(w, MajorKind::UnsignedInt, #i as u64)?;
                             #value
                         }
                     }
@@ -208,7 +210,7 @@ fn gen_encode_union(u: &Union) -> TokenStream {
 }
 
 fn gen_decode_struct(s: &Struct) -> TokenStream {
-    let len = s.fields.len();
+    let len = s.fields.len() as u64;
     let construct = &*s.construct;
     match s.repr {
         StructRepr::Map => {
@@ -232,10 +234,10 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                 })
                 .collect();
             quote! {
-                let major = read_u8(r)?;
-                match major {
-                    0xa0..=0xbb => {
-                        let len = read_len(r, major - 0xa0)?;
+                let major = read_major(r)?;
+                match major.kind() {
+                    MajorKind::Map => {
+                        let len = read_uint(r, major)?;
                         if len > #len {
                             return Err(LengthOutOfRange::new::<Self>().into());
                         }
@@ -255,30 +257,8 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
 
                         return Ok(#construct);
                     }
-                    0xbf => {
-                        #(let mut #binding = None;)*
-                        loop {
-                            let major = read_u8(r)?;
-                            if major == 0xff {
-                                break;
-                            }
-                            r.seek(SeekFrom::Current(-1))?;
-                            let key = String::decode(c, r)?;
-                            match key.as_str() {
-                                #(#key => { #binding = Some(Decode::decode(c, r)?); })*
-                                _ => {
-                                    libipld::Ipld::decode(c, r)?;
-                                    //return Err(UnexpectedKey::new::<Self>(key).into()),
-                                }
-                            }
-                        }
-
-                        #(#fields)*
-
-                        return Ok(#construct);
-                    }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -291,10 +271,10 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                 }
             });
             quote! {
-                let major = read_u8(r)?;
-                match major {
-                    0x80..=0x9b => {
-                        let len = read_len(r, major - 0x80)?;
+                let major = read_major(r)?;
+                match major.kind() {
+                    MajorKind::Array => {
+                        let len = read_uint(r, major)?;
                         if len != #len {
                             return Err(LengthOutOfRange::new::<Self>().into());
                         }
@@ -302,7 +282,7 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                         return Ok(#construct);
                     }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -318,13 +298,13 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
         StructRepr::Null => {
             assert_eq!(s.fields.len(), 0);
             quote! {
-                let major = read_u8(r)?;
+                let major = read_major(r)?;
                 match major {
-                    0xf6..=0xf7 => {
+                    NULL => {
                         return Ok(#construct);
                     }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -345,9 +325,11 @@ fn gen_decode_union(u: &Union) -> TokenStream {
                 }
             });
             quote! {
-                let major = read_u8(r)?;
-                if major != 0xa1 {
-                    return Err(UnexpectedCode::new::<Self>(major).into());
+                let major = read_major(r)?;
+                if major.kind() != MajorKind::Map {
+                    return Err(UnexpectedCode::new::<Self>(major.into()).into());
+                } else if read_uint(r, major)? != 1 {
+                    return Err(LengthOutOfRange::new::<Self>().into());
                 }
                 let key: String = Decode::decode(c, r)?;
                 #(#variants;)*
@@ -355,6 +337,7 @@ fn gen_decode_union(u: &Union) -> TokenStream {
             }
         }
         UnionRepr::Kinded => {
+            // TODO: this is wrong. Kinded should be based on the kind, not "if it decodes".
             let variants = u.variants.iter().map(|s| {
                 let parse = gen_decode_struct(s);
                 quote! {
@@ -372,7 +355,7 @@ fn gen_decode_union(u: &Union) -> TokenStream {
             });
             quote! {
                 #(#variants;)*
-                Err(UnexpectedCode::new::<Self>(read_u8(r)?).into())
+                Err(UnexpectedCode::new::<Self>(read_major(r)?.into()).into())
             }
         }
         UnionRepr::String => {
@@ -406,15 +389,19 @@ fn gen_decode_union(u: &Union) -> TokenStream {
         }
         UnionRepr::IntTuple => {
             let variants = u.variants.iter().enumerate().map(|(i, s)| {
+                let i = i as u64;
                 let parse = gen_decode_struct(s);
                 quote!(#i => { #parse })
             });
             quote! {
-                let major = read_u8(r)?;
-                if major != 0x82 {
-                    return Err(UnexpectedCode::new::<Self>(major).into());
+                let major = read_major(r)?;
+                if major.kind() != MajorKind::Array {
+                    return Err(UnexpectedCode::new::<Self>(major.into()).into());
                 }
-                let ty = read_u8(r)? as usize;
+                if read_uint(r, major)? != 2 {
+                    return Err(LengthOutOfRange::new::<Self>().into());
+                }
+                let ty: u64 = Decode::decode(c, r)?;
                 match ty {
                     #(#variants,)*
                     _ => return Err(UnexpectedKey::new::<Self>(ty.to_string()).into()),

--- a/dag-cbor-derive/tests/struct.rs
+++ b/dag-cbor-derive/tests/struct.rs
@@ -1,5 +1,5 @@
 use libipld::cbor::{DagCbor, DagCborCodec};
-use libipld::codec::{assert_roundtrip, Codec};
+use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor};
 
 #[derive(Clone, Copy, DagCbor, Debug, Eq, PartialEq)]

--- a/dag-cbor-derive/tests/struct.rs
+++ b/dag-cbor-derive/tests/struct.rs
@@ -153,21 +153,5 @@ pub struct IlMap {
     amt: i32,
 }
 
-#[test]
-fn serde_cbor_compat() {
-    let bytes = [
-        0xBF, // Start indefinite-length map
-        0x63, // First key, UTF-8 string length 3
-        0x46, 0x75, 0x6e, // "Fun"
-        0xF5, // First value, true
-        0x63, // Second key, UTF-8 string length 3
-        0x41, 0x6d, 0x74, // "Amt"
-        0x21, // Second value, -2
-        0xFF, // "break"
-    ];
-    let il_map: IlMap = DagCborCodec.decode(&bytes).unwrap();
-    assert_eq!(il_map, IlMap { fun: true, amt: -2 });
-}
-
 #[derive(DagCbor)]
 pub struct Generic<T: DagCbor>(T);

--- a/dag-cbor/src/cbor.rs
+++ b/dag-cbor/src/cbor.rs
@@ -42,11 +42,12 @@ impl Major {
 
     /// Interprets the additioanl info as a number of additional bytes that should be consumed.
     #[inline(always)]
+    #[allow(clippy::len_without_is_empty)]
     pub const fn len(self) -> u8 {
         // All major types follow the same rules for "additioanl bytes".
         // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
         match self.info() {
-            info @ 24..=27 => (1 << info - 24),
+            info @ 24..=27 => 1 << (info - 24),
             _ => 0,
         }
     }

--- a/dag-cbor/src/cbor.rs
+++ b/dag-cbor/src/cbor.rs
@@ -1,0 +1,107 @@
+//! CBOR helper types for encoding and decoding.
+use std::convert::TryFrom;
+
+use crate::error::UnexpectedCode;
+use libipld_core::ipld::Ipld;
+
+/// Represents a major "byte". This includes both the major bits and the additional info.
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct Major(u8);
+
+/// The constant TRUE.
+pub const FALSE: Major = Major::new(MajorKind::Other, 20);
+/// The constant FALSE.
+pub const TRUE: Major = Major::new(MajorKind::Other, 21);
+/// The constant NULL.
+pub const NULL: Major = Major::new(MajorKind::Other, 22);
+/// The major "byte" indicating that a 16 bit float follows.
+pub const F16: Major = Major::new(MajorKind::Other, 25);
+/// The major "byte" indicating that a 32 bit float follows.
+pub const F32: Major = Major::new(MajorKind::Other, 26);
+/// The major "byte" indicating that a 64 bit float follows.
+pub const F64: Major = Major::new(MajorKind::Other, 27);
+
+impl Major {
+    const fn new(kind: MajorKind, info: u8) -> Self {
+        Major(((kind as u8) << 5) | info)
+    }
+
+    /// Returns the major type.
+    #[inline(always)]
+    pub const fn kind(self) -> MajorKind {
+        // This is a 3 bit value, so value 0-7 are covered.
+        unsafe { std::mem::transmute(self.0 >> 5) }
+    }
+
+    /// Returns the additional info.
+    #[inline(always)]
+    pub const fn info(self) -> u8 {
+        self.0 & 0x1f
+    }
+
+    /// Interprets the additioanl info as a number of additional bytes that should be consumed.
+    #[inline(always)]
+    pub const fn len(self) -> u8 {
+        // All major types follow the same rules for "additioanl bytes".
+        // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
+        match self.info() {
+            info @ 24..=27 => (1 << info - 24),
+            _ => 0,
+        }
+    }
+}
+
+impl From<Major> for u8 {
+    fn from(m: Major) -> u8 {
+        m.0
+    }
+}
+
+// This is the core of the validation logic. Every major type passes through here giving us a chance
+// to determine if it's something we allow.
+impl TryFrom<u8> for Major {
+    type Error = UnexpectedCode;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        // We don't allow any major types with additional info 28-31 inclusive.
+        // Or the bitmask 0b00011100 = 28.
+        if value & 28 == 28 {
+            return Err(UnexpectedCode::new::<Ipld>(value));
+        } else if (value >> 5) == MajorKind::Other as u8 {
+            match value & 0x1f {
+                // False, True, Null. TODO: Allow undefined?
+                20 | 21 | 22 => (),
+                // Floats. TODO: forbid f16 & f32?
+                25 | 26 | 27 => (),
+                // Everything is forbidden.
+                _ => {
+                    return Err(UnexpectedCode::new::<Ipld>(value));
+                }
+            }
+        }
+        Ok(Major(value))
+    }
+}
+
+/// The type
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum MajorKind {
+    /// Non-negative integer (major type 0).
+    UnsignedInt = 0,
+    /// Negative integer (major type 1).
+    NegativeInt = 1,
+    /// Byte string (major type 2).
+    ByteString = 2,
+    /// Unicode text string (major type 3).
+    TextString = 3,
+    /// Array (major type 4).
+    Array = 4,
+    /// Map (major type 5).
+    Map = 5,
+    /// Tag (major type 6).
+    Tag = 6,
+    /// Other (major type 7).
+    Other = 7,
+}

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -1,7 +1,7 @@
 //! CBOR decoder
 use crate::error::{
-    IndefiniteLengthItem, InvalidCidPrefix, LengthOutOfRange, UnexpectedCode, UnexpectedEof,
-    UnknownTag,
+    InvalidCidPrefix, LengthOutOfRange, NumberNotMinimal, NumberOutOfRange, UnexpectedCode,
+    UnexpectedEof, UnknownTag,
 };
 use crate::DagCborCodec as DagCbor;
 use byteorder::{BigEndian, ByteOrder};
@@ -14,50 +14,132 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct Major(u8);
+
+impl Major {
+    const fn new(kind: MajorKind, info: u8) -> Self {
+        Major(((kind as u8) << 5) | info)
+    }
+
+    #[inline(always)]
+    const fn kind(self) -> MajorKind {
+        // This is a 3 bit value, so value 0-7 are covered.
+        unsafe { std::mem::transmute(self.0 >> 5) }
+    }
+
+    #[inline(always)]
+    const fn info(self) -> u8 {
+        self.0 & 0x1f
+    }
+
+    #[inline(always)]
+    const fn len(self) -> u8 {
+        // All major types follow the same rules for "additioanl bytes".
+        // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
+        match self.info() {
+            info @ 24..=27 => (1 << info - 24),
+            _ => 0,
+        }
+    }
+}
+
+// This is the core of the validation logic. Every major type passes through here giving us a chance
+// to determine if it's something we allow.
+impl TryFrom<u8> for Major {
+    type Error = UnexpectedCode;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        // We don't allow any major types with additional info 28-31 inclusive.
+        // Or the bitmask 0b00011100 = 28.
+        if value & 28 == 28 {
+            return Err(UnexpectedCode::new::<Ipld>(value));
+        } else if (value >> 5) == MajorKind::Other as u8 {
+            match value & 0x1f {
+                // False, True, Null. TODO: Allow undefined?
+                20 | 21 | 22 => (),
+                // Floats. TODO: forbid f16 & f32?
+                25 | 26 | 27 => (),
+                // Everything is forbidden.
+                _ => {
+                    return Err(UnexpectedCode::new::<Ipld>(value));
+                }
+            }
+        }
+        Ok(Major(value))
+    }
+}
+
+mod consts {
+    use super::Major;
+    use super::MajorKind::*;
+
+    pub(super) const FALSE: Major = Major::new(Other, 20);
+    pub(super) const TRUE: Major = Major::new(Other, 21);
+    pub(super) const NULL: Major = Major::new(Other, 22);
+    pub(super) const F32: Major = Major::new(Other, 26);
+    pub(super) const F64: Major = Major::new(Other, 27);
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[allow(dead_code)]
+enum MajorKind {
+    UnsignedInt = 0,
+    NegativeInt = 1,
+    ByteString = 2,
+    TextString = 3,
+    Array = 4,
+    Map = 5,
+    Tag = 6,
+    Other = 7,
+}
+
 /// Reads a u8 from a byte stream.
-pub fn read_u8<R: Read + Seek>(r: &mut R) -> Result<u8> {
+pub fn read_u8<R: Read>(r: &mut R) -> Result<u8> {
     let mut buf = [0; 1];
     r.read_exact(&mut buf)?;
     Ok(buf[0])
 }
 
 /// Reads a u16 from a byte stream.
-pub fn read_u16<R: Read + Seek>(r: &mut R) -> Result<u16> {
+pub fn read_u16<R: Read>(r: &mut R) -> Result<u16> {
     let mut buf = [0; 2];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u16(&buf))
 }
 
 /// Reads a u32 from a byte stream.
-pub fn read_u32<R: Read + Seek>(r: &mut R) -> Result<u32> {
+pub fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
     let mut buf = [0; 4];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u32(&buf))
 }
 
 /// Reads a u64 from a byte stream.
-pub fn read_u64<R: Read + Seek>(r: &mut R) -> Result<u64> {
+pub fn read_u64<R: Read>(r: &mut R) -> Result<u64> {
     let mut buf = [0; 8];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u64(&buf))
 }
 
 /// Reads a f32 from a byte stream.
-pub fn read_f32<R: Read + Seek>(r: &mut R) -> Result<f32> {
+pub fn read_f32<R: Read>(r: &mut R) -> Result<f32> {
     let mut buf = [0; 4];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_f32(&buf))
 }
 
 /// Reads a f64 from a byte stream.
-pub fn read_f64<R: Read + Seek>(r: &mut R) -> Result<f64> {
+pub fn read_f64<R: Read>(r: &mut R) -> Result<f64> {
     let mut buf = [0; 8];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_f64(&buf))
 }
 
 /// Reads `len` number of bytes from a byte stream.
-pub fn read_bytes<R: Read + Seek>(r: &mut R, len: usize) -> Result<Vec<u8>> {
+pub fn read_bytes<R: Read>(r: &mut R, len: u64) -> Result<Vec<u8>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     // Limit up-front allocations to 16KiB as the length is user controlled.
     let mut buf = Vec::with_capacity(len.min(16 * 1024));
     r.take(len as u64).read_to_end(&mut buf)?;
@@ -68,13 +150,14 @@ pub fn read_bytes<R: Read + Seek>(r: &mut R, len: usize) -> Result<Vec<u8>> {
 }
 
 /// Reads `len` number of bytes from a byte stream and converts them to a string.
-pub fn read_str<R: Read + Seek>(r: &mut R, len: usize) -> Result<String> {
+pub fn read_str<R: Read>(r: &mut R, len: u64) -> Result<String> {
     let bytes = read_bytes(r, len)?;
     Ok(String::from_utf8(bytes)?)
 }
 
 /// Reads a list of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
-pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: usize) -> Result<Vec<T>> {
+pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: u64) -> Result<Vec<T>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     // Limit up-front allocations to 16KiB as the length is user controlled.
     //
     // Can't make this "const" because the generic, but it _should_ be known at compile time.
@@ -90,8 +173,9 @@ pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: usize) -> R
 /// Reads a map of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
 pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
     r: &mut R,
-    len: usize,
+    len: u64,
 ) -> Result<BTreeMap<K, T>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     let mut map: BTreeMap<K, T> = BTreeMap::new();
     for _ in 0..len {
         let key = K::decode(DagCbor, r)?;
@@ -103,258 +187,198 @@ pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
 
 /// Reads a cid from a stream of cbor encoded bytes.
 pub fn read_link<R: Read + Seek>(r: &mut R) -> Result<Cid> {
-    let ty = read_u8(r)?;
-    if ty != 0x58 {
-        return Err(UnknownTag(ty).into());
+    let major = read_major(r)?;
+    if major.kind() != MajorKind::ByteString {
+        return Err(UnexpectedCode::new::<Cid>(major.0).into());
     }
-    let len = read_u8(r)?;
-    if len == 0 {
+    let len = read_uint(r, major)?;
+    if len < 1 {
         return Err(LengthOutOfRange::new::<Cid>().into());
     }
-    let bytes = read_bytes(r, len as usize)?;
-    if bytes[0] != 0 {
-        return Err(InvalidCidPrefix(bytes[0]).into());
-    }
+
+    let mut r = r.take(len);
 
     // skip the first byte per
     // https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#links
-    Ok(Cid::try_from(&bytes[1..])?)
+    let prefix = read_u8(&mut r)?;
+    if prefix != 0 {
+        return Err(InvalidCidPrefix(prefix).into());
+    }
+
+    // Read the CID. No need to limit the size, the CID will do this for us.
+    let cid = Cid::read_bytes(&mut r)?;
+
+    // Make sure we've read the entire CID.
+    if r.read(&mut [0u8][..])? != 0 {
+        return Err(LengthOutOfRange::new::<Cid>().into());
+    }
+
+    Ok(cid)
 }
 
-/// Reads the len given a base.
-pub fn read_len<R: Read + Seek>(r: &mut R, major: u8) -> Result<usize> {
-    Ok(match major {
-        0x00..=0x17 => major as usize,
-        0x18 => read_u8(r)? as usize,
-        0x19 => read_u16(r)? as usize,
-        0x1a => read_u32(r)? as usize,
-        0x1b => {
-            let len = read_u64(r)?;
-            if len > usize::max_value() as u64 {
-                return Err(LengthOutOfRange::new::<usize>().into());
-            }
-            len as usize
-        }
-        major => return Err(UnexpectedCode::new::<usize>(major).into()),
-    })
+fn read_major<R: Read>(r: &mut R) -> Result<Major> {
+    Ok(Major::try_from(read_u8(r)?)?)
+}
+
+fn read_uint<R: Read>(r: &mut R, major: Major) -> Result<u64> {
+    const MAX_SHORT: u64 = 23;
+    const MAX_1BYTE: u64 = u8::MAX as u64;
+    const MAX_2BYTE: u64 = u16::MAX as u64;
+    const MAX_4BYTE: u64 = u32::MAX as u64;
+    match major.info() {
+        value @ 0..=23 => Ok(value as u64),
+        24 => match read_u8(r)? as u64 {
+            0..=MAX_SHORT => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        25 => match read_u16(r)? as u64 {
+            0..=MAX_1BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        26 => match read_u32(r)? as u64 {
+            0..=MAX_2BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        27 => match read_u64(r)? as u64 {
+            0..=MAX_4BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        _ => return Err(UnexpectedCode::new::<usize>(major.0).into()),
+    }
 }
 
 impl Decode<DagCbor> for bool {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xf4 => false,
-            0xf5 => true,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        Ok(match read_major(r)? {
+            consts::FALSE => false,
+            consts::TRUE => true,
+            Major(n) => return Err(UnexpectedCode::new::<Self>(n).into()),
+        })
     }
 }
 
-impl Decode<DagCbor> for u8 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major,
-            0x18 => read_u8(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
+macro_rules! impl_num {
+    (unsigned $($t:ty),*) => {
+        $(
+            impl Decode<DagCbor> for $t {
+                fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
+                    let major = read_major(r)?;
+                    if major.kind() != MajorKind::UnsignedInt {
+                        return Err(UnexpectedCode::new::<Self>(major.0).into());
+                    }
+                    let value = read_uint(r, major)?;
+                    Self::try_from(value).map_err(|_| NumberOutOfRange::new::<Self>().into())
+                }
             }
-        };
-        Ok(result)
-    }
+        )*
+    };
+    (signed $($t:ty),*) => {
+        $(
+            impl Decode<DagCbor> for $t {
+                fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
+                    let major = read_major(r)?;
+                    let value = read_uint(r, major)?;
+                    match major.kind() {
+                        MajorKind::UnsignedInt | MajorKind::NegativeInt => (),
+                        _ => return Err(UnexpectedCode::new::<Self>(major.0).into()),
+                    };
+
+                    let mut value = Self::try_from(value)
+                        .map_err(|_| NumberOutOfRange::new::<Self>())?;
+                    if major.kind() == MajorKind::NegativeInt {
+                        // This is guaranteed to not overflow.
+                        value = -1 - value;
+                    }
+                    Ok(value)
+                }
+            }
+        )*
+    };
 }
 
-impl Decode<DagCbor> for u16 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u16,
-            0x18 => read_u8(r)? as u16,
-            0x19 => read_u16(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for u32 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u32,
-            0x18 => read_u8(r)? as u32,
-            0x19 => read_u16(r)? as u32,
-            0x1a => read_u32(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for u64 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u64,
-            0x18 => read_u8(r)? as u64,
-            0x19 => read_u16(r)? as u64,
-            0x1a => read_u32(r)? as u64,
-            0x1b => read_u64(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i8 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i8,
-            0x38 => -1 - read_u8(r)? as i8,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i16 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i16,
-            0x38 => -1 - read_u8(r)? as i16,
-            0x39 => -1 - read_u16(r)? as i16,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i32 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i32,
-            0x38 => -1 - read_u8(r)? as i32,
-            0x39 => -1 - read_u16(r)? as i32,
-            0x3a => -1 - read_u32(r)? as i32,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i64 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i64,
-            0x38 => -1 - read_u8(r)? as i64,
-            0x39 => -1 - read_u16(r)? as i64,
-            0x3a => -1 - read_u32(r)? as i64,
-            0x3b => -1 - read_u64(r)? as i64,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
+impl_num!(unsigned u8, u16, u32, u64, u128);
+impl_num!(signed i8, i16, i32, i64, i128);
 
 impl Decode<DagCbor> for f32 {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xfa => read_f32(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
+        // TODO: We don't accept f16
+        // TODO: By IPLD spec, we shouldn't accept f32 either...
+        let num = match read_major(r)? {
+            consts::F32 => f32::from_bits(read_u32(r)?),
+            consts::F64 => {
+                let num = f64::from_bits(read_u64(r)?);
+                let converted = num as Self;
+                if f64::from(converted) != num {
+                    return Err(NumberOutOfRange::new::<Self>().into());
+                }
+                converted
             }
+            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
         };
-        Ok(result)
+        if !num.is_finite() {
+            return Err(NumberOutOfRange::new::<Self>().into());
+        }
+        Ok(num)
     }
 }
 
 impl Decode<DagCbor> for f64 {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xfa => read_f32(r)? as f64,
-            0xfb => read_f64(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
+        // TODO: We don't accept f16
+        // TODO: By IPLD spec, we shouldn't accept f32 either...
+        let num = match read_major(r)? {
+            consts::F32 => f32::from_bits(read_u32(r)?).into(),
+            consts::F64 => f64::from_bits(read_u64(r)?),
+            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
         };
-        Ok(result)
+        // This is by IPLD spec, but is it widely used?
+        if !num.is_finite() {
+            return Err(NumberOutOfRange::new::<Self>().into());
+        }
+        Ok(num)
     }
 }
 
 impl Decode<DagCbor> for String {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                read_str(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::TextString {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        read_str(r, len)
     }
 }
 
 impl Decode<DagCbor> for Cid {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        if major == 0xd8 {
-            if let Ok(tag) = read_u8(r) {
-                if tag == 42 {
-                    return read_link(r);
-                }
+        let major = read_major(r)?;
+        if major.kind() == MajorKind::Tag {
+            match read_uint(r, major)? {
+                42 => read_link(r),
+                tag => Err(UnknownTag(tag).into()),
             }
+        } else {
+            Err(UnexpectedCode::new::<Self>(major.0).into())
         }
-        Err(UnexpectedCode::new::<Self>(major).into())
     }
 }
 
 impl Decode<DagCbor> for Box<[u8]> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                read_bytes(r, len)?.into_boxed_slice()
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::ByteString {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        Ok(read_bytes(r, len)?.into_boxed_slice())
     }
 }
 
 impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
     fn decode<R: Read + Seek>(c: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xf6 => None,
+        let result = match read_major(r)? {
+            consts::NULL => None,
             _ => {
                 r.seek(SeekFrom::Current(-1))?;
                 Some(T::decode(c, r)?)
@@ -366,110 +390,76 @@ impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
 
 impl<T: Decode<DagCbor>> Decode<DagCbor> for Vec<T> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                read_list(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::Array {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        read_list(r, len)
     }
 }
 
 impl<K: Decode<DagCbor> + Ord, T: Decode<DagCbor>> Decode<DagCbor> for BTreeMap<K, T> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                read_map(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::Map {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+
+        let len = read_uint(r, major)?;
+        read_map(r, len)
     }
 }
 
 impl Decode<DagCbor> for Ipld {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let ipld = match major {
-            // Major type 0: an unsigned integer
-            0x00..=0x17 => Self::Integer(major as i128),
-            0x18 => Self::Integer(read_u8(r)? as i128),
-            0x19 => Self::Integer(read_u16(r)? as i128),
-            0x1a => Self::Integer(read_u32(r)? as i128),
-            0x1b => Self::Integer(read_u64(r)? as i128),
-
-            // Major type 1: a negative integer
-            0x20..=0x37 => Self::Integer(-1 - (major - 0x20) as i128),
-            0x38 => Self::Integer(-1 - read_u8(r)? as i128),
-            0x39 => Self::Integer(-1 - read_u16(r)? as i128),
-            0x3a => Self::Integer(-1 - read_u32(r)? as i128),
-            0x3b => Self::Integer(-1 - read_u64(r)? as i128),
-
-            // Major type 2: a byte string
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                let bytes = read_bytes(r, len as usize)?;
-                Self::Bytes(bytes)
+        let major = read_major(r)?;
+        let ipld = match major.kind() {
+            MajorKind::UnsignedInt => Self::Integer(read_uint(r, major)? as i128),
+            MajorKind::NegativeInt => Self::Integer(-1 - read_uint(r, major)? as i128),
+            MajorKind::ByteString => {
+                let len = read_uint(r, major)?;
+                Self::Bytes(read_bytes(r, len)?)
             }
-
-            // Major type 3: a text string
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                let string = read_str(r, len as usize)?;
-                Self::String(string)
+            MajorKind::TextString => {
+                let len = read_uint(r, major)?;
+                Self::String(read_str(r, len)?)
             }
-
-            // Major type 4: an array of data items
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                let list = read_list(r, len as usize)?;
-                Self::List(list)
+            MajorKind::Array => {
+                let len = read_uint(r, major)?;
+                Self::List(read_list(r, len)?)
             }
-
-            // Major type 5: a map of pairs of data items
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
+            MajorKind::Map => {
+                let len = read_uint(r, major)?;
                 #[cfg(feature = "unleashed")]
                 if len > 0 {
                     let pos = r.seek(SeekFrom::Current(0))?;
-                    if let Ok(map) = read_map(r, len as usize) {
+                    if let Ok(map) = read_map(r, len) {
                         return Ok(Self::IntegerMap(map));
                     }
                     r.seek(SeekFrom::Start(pos))?;
                 }
-                Self::StringMap(read_map(r, len as usize)?)
+                Self::StringMap(read_map(r, len)?)
             }
-
-            // Major type 6: optional semantic tagging of other major types
-            0xd8 => {
-                let tag = read_u8(r)?;
-                if tag == 42 {
+            MajorKind::Tag => {
+                let value = read_uint(r, major)?;
+                if value == 42 {
                     Self::Link(read_link(r)?)
                 } else {
                     #[cfg(not(feature = "unleashed"))]
-                    return Err(UnknownTag(tag).into());
+                    return Err(UnknownTag(value).into());
                     #[cfg(feature = "unleashed")]
-                    Self::Tag(tag as _, Box::new(Self::decode(DagCbor, r)?))
+                    Self::Tag(value as _, Box::new(Self::decode(DagCbor, r)?))
                 }
             }
-
-            // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4 => Self::Bool(false),
-            0xf5 => Self::Bool(true),
-            0xf6 => Self::Null,
-            0xfa => Self::Float(read_f32(r)? as f64),
-            0xfb => Self::Float(read_f64(r)?),
-            0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
-            _ => return Err(UnexpectedCode::new::<Self>(major).into()),
+            MajorKind::Other => match major {
+                consts::FALSE => Self::Bool(false),
+                consts::TRUE => Self::Bool(true),
+                consts::NULL => Self::Null,
+                consts::F32 => Self::Float(f32::from_bits(read_u32(r)?).into()),
+                consts::F64 => Self::Float(f64::from_bits(read_u64(r)?).into()),
+                Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
+            },
         };
         Ok(ipld)
     }
@@ -481,102 +471,49 @@ impl References<DagCbor> for Ipld {
         r: &mut R,
         set: &mut E,
     ) -> Result<()> {
-        let mut remaining: usize = 1;
+        let mut remaining: u64 = 1;
         while remaining > 0 {
-            let major = read_u8(r)?;
-            match major {
-                // Major type 0: an unsigned integer
-                0x00..=0x17 => {}
-                0x18 => {
-                    r.seek(SeekFrom::Current(1))?;
+            remaining -= 1;
+            let major = read_major(r)?;
+            match major.kind() {
+                MajorKind::UnsignedInt | MajorKind::NegativeInt | MajorKind::Other => {
+                    // TODO: validate ints & floats?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
                 }
-                0x19 => {
-                    r.seek(SeekFrom::Current(2))?;
+                MajorKind::ByteString | MajorKind::TextString => {
+                    // TODO: validate utf8?
+                    // We could just reject this case, but we can't just play it fast and loose and
+                    // wrap. We might as well just try to seek (and likely fail).
+                    let mut offset = read_uint(r, major)?;
+                    while offset > i64::MAX as u64 {
+                        r.seek(SeekFrom::Current(i64::MAX))?;
+                        offset -= i64::MAX as u64;
+                    }
+                    r.seek(SeekFrom::Current(offset as i64))?;
                 }
-                0x1a => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0x1b => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-
-                // Major type 1: a negative integer
-                0x20..=0x37 => {}
-                0x38 => {
-                    r.seek(SeekFrom::Current(1))?;
-                }
-                0x39 => {
-                    r.seek(SeekFrom::Current(2))?;
-                }
-                0x3a => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0x3b => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-
-                // Major type 2: a byte string
-                0x40..=0x5b => {
-                    let len = read_len(r, major - 0x40)?;
-                    r.seek(SeekFrom::Current(len as _))?;
-                }
-
-                // Major type 3: a text string
-                0x60..=0x7b => {
-                    let len = read_len(r, major - 0x60)?;
-                    r.seek(SeekFrom::Current(len as _))?;
-                }
-
-                // Major type 4: an array of data items
-                0x80..=0x9b => {
-                    let len = read_len(r, major - 0x80)?;
+                MajorKind::Array => {
                     remaining = remaining
-                        .checked_add(len)
+                        .checked_add(read_uint(r, major)?)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                 }
-
-                // Major type 5: a map of pairs of data items
-                0xa0..=0xbb => {
-                    let len = read_len(r, major - 0xa0)?;
+                MajorKind::Map => {
                     // TODO: consider using a checked "monad" type to simplify.
-                    let items = len
+                    let items = read_uint(r, major)?
                         .checked_mul(2)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                     remaining = remaining
                         .checked_add(items)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                 }
-
-                // Major type 6: optional semantic tagging of other major types
-                0xd8 => {
-                    let tag = read_u8(r)?;
-                    if tag == 42 {
-                        set.extend(std::iter::once(read_link(r)?));
-                    } else {
+                MajorKind::Tag => match read_uint(r, major)? {
+                    42 => set.extend(std::iter::once(read_link(r)?)),
+                    _ => {
                         remaining = remaining
                             .checked_add(1)
                             .ok_or_else(LengthOutOfRange::new::<Self>)?;
                     }
-                }
-
-                // Major type 7: floating-point numbers and other simple data types that need no content
-                0xf4..=0xf7 => {}
-                0xf8 => {
-                    r.seek(SeekFrom::Current(1))?;
-                }
-                0xf9 => {
-                    r.seek(SeekFrom::Current(2))?;
-                }
-                0xfa => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0xfb => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-                0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
-                major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
+                },
             };
-            remaining -= 1;
         }
         Ok(())
     }
@@ -662,106 +599,50 @@ impl<A: Decode<DagCbor>, B: Decode<DagCbor>, C: Decode<DagCbor>, D: Decode<DagCb
 
 impl SkipOne for DagCbor {
     fn skip<R: Read + Seek>(&self, r: &mut R) -> Result<()> {
-        let major = read_u8(r)?;
-        match major {
-            // Major type 0: an unsigned integer
-            0x00..=0x17 => {}
-            0x18 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x19 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x1a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x1b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 1: a negative integer
-            0x20..=0x37 => {}
-            0x38 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x39 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x3a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x3b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 2: a byte string
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 3: a text string
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 4: an array of data items
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                for _ in 0..len {
-                    self.skip(r)?;
+        let mut remaining: u64 = 1;
+        while remaining > 0 {
+            remaining -= 1;
+            let major = read_major(r)?;
+            match major.kind() {
+                MajorKind::UnsignedInt | MajorKind::NegativeInt | MajorKind::Other => {
+                    // TODO: validate?
+                    // minimal integer, valid float, etc?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
                 }
-            }
-
-            // Major type 5: a map of pairs of data items
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                for _ in 0..len {
-                    self.skip(r)?;
-                    self.skip(r)?;
+                MajorKind::ByteString | MajorKind::TextString => {
+                    // We could just reject this case, but we can't just play it fast and loose and
+                    // wrap. We might as well just try to seek (and likely fail).
+                    let mut offset = read_uint(r, major)?;
+                    while offset > i64::MAX as u64 {
+                        r.seek(SeekFrom::Current(i64::MAX))?;
+                        offset -= i64::MAX as u64;
+                    }
+                    // TODO: validate utf8?
+                    r.seek(SeekFrom::Current(offset as i64))?;
                 }
-            }
-
-            // Major type 6: optional semantic tagging of other major types
-            0xc0..=0xd7 => {
-                // let _tag = major - 0xc0;
-                self.skip(r)?;
-            }
-            0xd8 => {
-                r.seek(SeekFrom::Current(1))?;
-                self.skip(r)?;
-            }
-
-            0xd9 => {
-                r.seek(SeekFrom::Current(2))?;
-                self.skip(r)?;
-            }
-            0xda => {
-                r.seek(SeekFrom::Current(4))?;
-                self.skip(r)?;
-            }
-            0xdb => {
-                r.seek(SeekFrom::Current(8))?;
-                self.skip(r)?;
-            }
-
-            // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4..=0xf7 => {}
-            0xf8 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0xf9 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0xfa => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0xfb => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-            major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
-        };
+                MajorKind::Array => {
+                    remaining = remaining
+                        .checked_add(read_uint(r, major)?)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+                MajorKind::Map => {
+                    // TODO: consider using a checked "monad" type to simplify.
+                    let items = read_uint(r, major)?
+                        .checked_mul(2)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                    remaining = remaining
+                        .checked_add(items)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+                MajorKind::Tag => {
+                    // TODO: validate tag?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
+                    remaining = remaining
+                        .checked_add(1)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+            };
+        }
         Ok(())
     }
 }

--- a/dag-cbor/src/error.rs
+++ b/dag-cbor/src/error.rs
@@ -19,6 +19,11 @@ impl NumberOutOfRange {
     }
 }
 
+/// Number is not minimally encoded.
+#[derive(Debug, Error)]
+#[error("Number not minimally encoded.")]
+pub struct NumberNotMinimal;
+
 /// Length larger than usize or too small, for example zero length cid field.
 #[derive(Debug, Error)]
 #[error("Length out of range when decoding {ty}.")]
@@ -99,7 +104,7 @@ impl MissingKey {
 /// Unknown cbor tag.
 #[derive(Debug, Error)]
 #[error("Unkown cbor tag `{0}`.")]
-pub struct UnknownTag(pub u8);
+pub struct UnknownTag(pub u64);
 
 /// Unexpected eof.
 #[derive(Debug, Error)]
@@ -110,20 +115,3 @@ pub struct UnexpectedEof;
 #[derive(Debug, Error)]
 #[error("Invalid Cid prefix: {0}")]
 pub struct InvalidCidPrefix(pub u8);
-
-/// DagCbor does not support indefinit length items (lists & maps).
-#[derive(Debug, Error)]
-#[error("Illegal cbor indefinite length item when decoding `{ty}`.")]
-pub struct IndefiniteLengthItem {
-    /// Type.
-    pub ty: &'static str,
-}
-
-impl IndefiniteLengthItem {
-    /// Creates a new `UnexpectedCode` error.
-    pub fn new<T>() -> Self {
-        Self {
-            ty: type_name::<T>(),
-        }
-    }
-}

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -6,6 +6,7 @@ use core::convert::TryFrom;
 use libipld_core::codec::{Codec, Decode, Encode};
 pub use libipld_core::error::{Result, UnsupportedCodec};
 
+pub mod cbor;
 pub mod decode;
 pub mod encode;
 pub mod error;

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -39,6 +39,7 @@ impl<T: Encode<DagCborCodec> + Decode<DagCborCodec>> DagCbor for T {}
 mod tests {
     use super::*;
     use libipld_core::cid::Cid;
+    use libipld_core::codec::assert_roundtrip;
     use libipld_core::ipld::Ipld;
     use libipld_core::multihash::{Code, MultihashDigest};
     use libipld_macro::ipld;
@@ -71,5 +72,29 @@ mod tests {
             .references::<Ipld, _>(&bytes, &mut set)
             .unwrap();
         assert!(set.contains(&cid));
+    }
+
+    #[test]
+    fn test_encode_max() {
+        assert_roundtrip(DagCborCodec, &i8::MAX, &Ipld::Integer(i8::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i16::MAX, &Ipld::Integer(i16::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i32::MAX, &Ipld::Integer(i32::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i64::MAX, &Ipld::Integer(i64::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u8::MAX, &Ipld::Integer(u8::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u16::MAX, &Ipld::Integer(u16::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u32::MAX, &Ipld::Integer(u32::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u64::MAX, &Ipld::Integer(u64::MAX as i128));
+    }
+
+    #[test]
+    fn test_encode_min() {
+        assert_roundtrip(DagCborCodec, &i8::MIN, &Ipld::Integer(i8::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i16::MIN, &Ipld::Integer(i16::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i32::MIN, &Ipld::Integer(i32::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i64::MIN, &Ipld::Integer(i64::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u8::MIN, &Ipld::Integer(u8::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u16::MIN, &Ipld::Integer(u16::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u32::MIN, &Ipld::Integer(u32::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u64::MIN, &Ipld::Integer(u64::MIN as i128));
     }
 }

--- a/dag-cbor/tests/roundtrip.rs
+++ b/dag-cbor/tests/roundtrip.rs
@@ -1,6 +1,6 @@
 use libipld_cbor::DagCborCodec;
 use libipld_core::{
-    codec::{assert_roundtrip, Codec, Decode},
+    codec::{assert_roundtrip, Codec, Decode, Encode},
     ipld::Ipld,
     raw_value::{IgnoredAny, RawValue, SkipOne},
 };
@@ -45,17 +45,31 @@ fn zero_length_cid() {
     let _: Ipld = DagCborCodec.decode(&input).unwrap();
 }
 
+// 3x some cbor and then some garbage
+fn cbor_seq() -> Vec<u8> {
+    let mut buf = Vec::new();
+    1u8.encode(DagCborCodec, &mut buf).unwrap();
+    (u16::MAX as u64 + 1)
+        .encode(DagCborCodec, &mut buf)
+        .unwrap();
+    vec![String::from("foo")]
+        .encode(DagCborCodec, &mut buf)
+        .unwrap();
+    buf.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+    buf
+}
+
 // test SkipOne trait for cbor
 #[test]
 fn skip() {
-    // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     DagCborCodec.skip(&mut r).unwrap();
-    assert_eq!(r.position(), 9);
+    assert_eq!(r.position(), 1);
     DagCborCodec.skip(&mut r).unwrap();
-    assert_eq!(r.position(), 18);
+    assert_eq!(r.position(), 6);
+    DagCborCodec.skip(&mut r).unwrap();
+    assert_eq!(r.position(), 11);
     assert!(DagCborCodec.skip(&mut r).is_err());
 }
 
@@ -63,13 +77,14 @@ fn skip() {
 #[test]
 fn ignored_any() {
     // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 9);
+    assert_eq!(r.position(), 1);
     let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 18);
+    assert_eq!(r.position(), 6);
+    let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
+    assert_eq!(r.position(), 11);
     let r: result::Result<IgnoredAny, _> = Decode::decode(DagCborCodec, &mut r);
     assert!(r.is_err());
 }
@@ -78,15 +93,17 @@ fn ignored_any() {
 #[test]
 fn raw_value() {
     // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 9);
-    assert_eq!(raw.as_ref(), &hex::decode("a163666f6fd82a5800").unwrap());
+    assert_eq!(r.position(), 1);
+    assert_eq!(raw.as_ref(), &input[0..1]);
     let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 18);
-    assert_eq!(raw.as_ref(), &hex::decode("a163666f6fd82a5800").unwrap());
+    assert_eq!(r.position(), 6);
+    assert_eq!(raw.as_ref(), &input[1..6]);
+    let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
+    assert_eq!(r.position(), 11);
+    assert_eq!(raw.as_ref(), &input[6..11]);
     let r: result::Result<RawValue<DagCborCodec>, _> = Decode::decode(DagCborCodec, &mut r);
     assert!(r.is_err());
 }


### PR DESCRIPTION
1. Correctly encode & decode positive signed integers.
2. Correctly handle integer overflow everywhere.
3. Correctly handle all tag types (can be 0-4 bytes).
4. Always encode floats as f64 (by DagCbor spec).
5. Enforce minimal integer encoding.
6. Reject almost everything that's not DagCbor.

To still consider:

1. Be stricter when skipping & scanning for refs:
    1. Validate integers.
    2. Validate floats.
    3. Validate utf8 in strings.
    4. Reject unrecognized tags.
2. Maybe allow on decode:
    1. Undefined.
    2. f16 decoding.
    3. nan, infinity, etc.
3. Maybe forbid on decode:
    1. f16 & f32 on decode.