### PR TITLE
fix: remove unleashed feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ dag-cbor = ["libipld-cbor"]
 dag-json = ["libipld-json"]
 dag-pb = ["libipld-pb"]
 derive = ["libipld-cbor-derive"]
-unleashed = ["libipld-core/unleashed", "libipld-cbor/unleashed", "libipld-json/unleashed"]
 
 [workspace]
 members = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "Base traits and definitions used by ipld codecs."
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
-[features]
-unleashed = []
-
 [dependencies]
 anyhow = "1.0.40"
 cid = { version = "0.7.0", default-features = false, features = ["std"] }

--- a/core/src/convert.rs
+++ b/core/src/convert.rs
@@ -53,8 +53,6 @@ derive_to_ipld!(Bytes, Box<[u8]>, into_vec);
 derive_to_ipld!(Bytes, Vec<u8>, into);
 derive_to_ipld!(Bytes, &[u8], to_vec);
 derive_to_ipld!(List, Vec<Ipld>, into);
-derive_to_ipld!(StringMap, BTreeMap<String, Ipld>, to_owned);
-#[cfg(feature = "unleashed")]
-derive_to_ipld!(IntegerMap, BTreeMap<i64, Ipld>, to_owned);
+derive_to_ipld!(Map, BTreeMap<String, Ipld>, to_owned);
 derive_to_ipld_generic!(Link, Cid, clone);
 derive_to_ipld_generic!(Link, &Cid, to_owned);

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -66,14 +66,10 @@ pub enum TypeErrorType {
     Bytes,
     /// List type.
     List,
-    /// StringMap type.
-    StringMap,
-    /// IntegerMap type.
-    IntegerMap,
+    /// Map type.
+    Map,
     /// Link type.
     Link,
-    /// Tag type.
-    Tag,
     /// Key type.
     Key(String),
     /// Index type.
@@ -96,12 +92,8 @@ impl From<&Ipld> for TypeErrorType {
             Ipld::String(_) => Self::String,
             Ipld::Bytes(_) => Self::Bytes,
             Ipld::List(_) => Self::List,
-            Ipld::StringMap(_) => Self::StringMap,
-            #[cfg(feature = "unleashed")]
-            Ipld::IntegerMap(_) => Self::IntegerMap,
+            Ipld::Map(_) => Self::Map,
             Ipld::Link(_) => Self::Link,
-            #[cfg(feature = "unleashed")]
-            Ipld::Tag(_, _) => Self::Tag,
         }
     }
 }

--- a/dag-cbor/Cargo.toml
+++ b/dag-cbor/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "ipld cbor codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
-[features]
-unleashed = ["libipld-core/unleashed"]
-
 [dependencies]
 byteorder = "1.4.3"
 libipld-core = { version = "0.12.0", path = "../core" }

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -477,26 +477,14 @@ impl Decode<DagCbor> for Ipld {
             // Major type 5: a map of pairs of data items
             0xa0..=0xbb => {
                 let len = read_len(r, major - 0xa0)?;
-                #[cfg(feature = "unleashed")]
-                if len > 0 {
-                    let pos = r.seek(SeekFrom::Current(0))?;
-                    if let Ok(map) = read_map(r, len as usize) {
-                        return Ok(Self::IntegerMap(map));
-                    }
-                    r.seek(SeekFrom::Start(pos))?;
-                }
-                Self::StringMap(read_map(r, len as usize)?)
+                Self::Map(read_map(r, len as usize)?)
             }
 
             // Major type 5: a map of pairs of data items (indefinite length)
             0xbf => {
                 let pos = r.seek(SeekFrom::Current(0))?;
-                #[cfg(feature = "unleashed")]
-                if let Ok(map) = read_map_il(r) {
-                    return Ok(Self::IntegerMap(map));
-                }
                 r.seek(SeekFrom::Start(pos))?;
-                Self::StringMap(read_map_il(r)?)
+                Self::Map(read_map_il(r)?)
             }
 
             // Major type 6: optional semantic tagging of other major types
@@ -505,10 +493,7 @@ impl Decode<DagCbor> for Ipld {
                 if tag == 42 {
                     Self::Link(read_link(r)?)
                 } else {
-                    #[cfg(not(feature = "unleashed"))]
                     return Err(UnknownTag(tag).into());
-                    #[cfg(feature = "unleashed")]
-                    Self::Tag(tag as _, Box::new(Self::decode(DagCbor, r)?))
                 }
             }
 

--- a/dag-cbor/src/encode.rs
+++ b/dag-cbor/src/encode.rs
@@ -262,15 +262,8 @@ impl Encode<DagCbor> for Ipld {
             Self::Bytes(b) => b.as_slice().encode(c, w),
             Self::String(s) => s.encode(c, w),
             Self::List(l) => l.encode(c, w),
-            Self::StringMap(m) => m.encode(c, w),
-            #[cfg(feature = "unleashed")]
-            Self::IntegerMap(m) => m.encode(c, w),
+            Self::Map(m) => m.encode(c, w),
             Self::Link(cid) => cid.encode(c, w),
-            #[cfg(feature = "unleashed")]
-            Self::Tag(tag, ipld) => {
-                write_tag(w, *tag)?;
-                ipld.encode(c, w)
-            }
         }
     }
 }

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "ipld json codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
-[features]
-unleashed = ["libipld-core/unleashed"]
-
 [dependencies]
 base64 = "0.13.0"
 libipld-core = { version = "0.12.0", path = "../core" }

--- a/dag-json/src/codec.rs
+++ b/dag-json/src/codec.rs
@@ -34,20 +34,9 @@ fn serialize<S: ser::Serializer>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
             let wrapped = list.iter().map(Wrapper);
             ser.collect_seq(wrapped)
         }
-        Ipld::StringMap(map) => {
+        Ipld::Map(map) => {
             let wrapped = map.iter().map(|(key, ipld)| (key, Wrapper(ipld)));
             ser.collect_map(wrapped)
-        }
-        #[cfg(feature = "unleashed")]
-        Ipld::IntegerMap(map) => {
-            let wrapped = map.iter().map(|(key, ipld)| (key, Wrapper(ipld)));
-            ser.collect_map(wrapped)
-        }
-        #[cfg(feature = "unleashed")]
-        Ipld::Tag(tag, ipld) => {
-            let mut map = BTreeMap::new();
-            map.insert("/", (tag, Wrapper(ipld)));
-            ser.collect_map(map)
         }
         Ipld::Link(link) => {
             let value = base64::encode(&link.to_bytes());
@@ -193,7 +182,7 @@ impl<'de> de::Visitor<'de> for JsonVisitor {
             .into_iter()
             .map(|(key, WrapperOwned(value))| (key, value))
             .collect();
-        Ok(Ipld::StringMap(unwrapped))
+        Ok(Ipld::Map(unwrapped))
     }
 
     fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("name".to_string(), Ipld::String("Hello World!".to_string()));
         map.insert("details".to_string(), Ipld::Link(cid));
-        let contact = Ipld::StringMap(map);
+        let contact = Ipld::Map(map);
 
         let contact_encoded = DagJsonCodec.encode(&contact).unwrap();
         println!("encoded: {:02x?}", contact_encoded);

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -252,11 +252,11 @@ macro_rules! ipld_internal {
     };
 
     ({}) => {
-        $crate::Ipld::StringMap(std::collections::BTreeMap::new())
+        $crate::Ipld::Map(std::collections::BTreeMap::new())
     };
 
     ({ $($tt:tt)+ }) => {
-        $crate::Ipld::StringMap({
+        $crate::Ipld::Map({
             let mut object = std::collections::BTreeMap::new();
             ipld_internal!(@object object () ($($tt)+) ($($tt)+));
             object

--- a/src/codec_impl.rs
+++ b/src/codec_impl.rs
@@ -219,7 +219,7 @@ mod tests {
         data_map.insert("Data".to_string(), Ipld::Bytes(b"data".to_vec()));
         data_map.insert("Links".to_string(), Ipld::List(vec![]));
 
-        let data = Ipld::StringMap(data_map);
+        let data = Ipld::Map(data_map);
         let result = IpldCodec::DagPb.encode(&data).unwrap();
         assert_eq!(result, vec![0x0a, 0x04, 0x64, 0x61, 0x74, 0x61]);
     }
@@ -230,7 +230,7 @@ mod tests {
         let mut data_map = std::collections::BTreeMap::<String, Ipld>::new();
         data_map.insert("Data".to_string(), Ipld::Bytes(b"data".to_vec()));
         data_map.insert("Links".to_string(), Ipld::List(vec![]));
-        let expected = Ipld::StringMap(data_map);
+        let expected = Ipld::Map(data_map);
 
         let data = [0x0a, 0x04, 0x64, 0x61, 0x74, 0x61];
         let result: Ipld = IpldCodec::DagPb.decode(&data).unwrap();


### PR DESCRIPTION
The unleashed feature was introduced to support a use case where non DAG-CBOR
compatible was used. That is no longer needed, hence removing this feature.
The goal is to become IPLD spec compliant.

Fixes #124.

BREAKING CHANGE: The IPLD enum variant `StringMap` is no called `Map`.