### PR TITLE
Spec compliant DAG-CBOR/DAG-JSON

### DIFF
--- a/dag-cbor-derive/src/gen.rs
+++ b/dag-cbor-derive/src/gen.rs
@@ -20,7 +20,7 @@ pub fn gen_encode(ast: &SchemaType) -> TokenStream {
                 w: &mut W,
             ) -> libipld::Result<()> {
                 use libipld::codec::Encode;
-                use libipld::cbor::cbor::*;
+                use libipld::cbor::cbor::MajorKind;
                 use libipld::cbor::encode::{write_null, write_u8, write_u64};
                 #body
             }
@@ -42,7 +42,7 @@ pub fn gen_decode(ast: &SchemaType) -> TokenStream {
                 c: libipld::cbor::DagCborCodec,
                 r: &mut R,
             ) -> libipld::Result<Self> {
-                use libipld::cbor::cbor::*;
+                use libipld::cbor::cbor::{MajorKind, NULL};
                 use libipld::cbor::decode::{read_uint, read_major};
                 use libipld::cbor::error::{LengthOutOfRange, MissingKey, UnexpectedCode, UnexpectedKey};
                 use libipld::codec::Decode;

--- a/dag-cbor-derive/src/gen.rs
+++ b/dag-cbor-derive/src/gen.rs
@@ -18,7 +18,8 @@ pub fn gen_encode(ast: &SchemaType) -> TokenStream {
                 w: &mut W,
             ) -> libipld::Result<()> {
                 use libipld::codec::Encode;
-                use libipld::cbor::encode::{write_null, write_u64};
+                use libipld::cbor::cbor::*;
+                use libipld::cbor::encode::{write_null, write_u8, write_u64};
                 #body
             }
         }
@@ -39,7 +40,8 @@ pub fn gen_decode(ast: &SchemaType) -> TokenStream {
                 c: libipld::cbor::DagCborCodec,
                 r: &mut R,
             ) -> libipld::Result<Self> {
-                use libipld::cbor::decode::{read_len, read_u8, read_u64};
+                use libipld::cbor::cbor::*;
+                use libipld::cbor::decode::{read_uint, read_major};
                 use libipld::cbor::error::{LengthOutOfRange, MissingKey, UnexpectedCode, UnexpectedKey};
                 use libipld::codec::Decode;
                 use libipld::error::Result;
@@ -121,7 +123,7 @@ fn gen_encode_struct_body(s: &Struct) -> TokenStream {
             quote! {
                 let mut len = #len;
                 #(#dfields)*
-                write_u64(w, 5, len)?;
+                write_u64(w, MajorKind::Map, len)?;
                 #(#fields)*
             }
         }
@@ -134,7 +136,7 @@ fn gen_encode_struct_body(s: &Struct) -> TokenStream {
                 }
             });
             quote! {
-                write_u64(w, 4, #len)?;
+                write_u64(w, MajorKind::Array, #len)?;
                 #(#fields)*
             }
         }
@@ -171,7 +173,7 @@ fn gen_encode_union(u: &Union) -> TokenStream {
                 UnionRepr::Keyed => {
                     quote! {
                         #pat => {
-                            write_u64(w, 5, 1)?;
+                            write_u8(w, MajorKind::Map, 1)?;
                             Encode::encode(#key, c, w)?;
                             #value
                         }
@@ -191,8 +193,8 @@ fn gen_encode_union(u: &Union) -> TokenStream {
                 UnionRepr::IntTuple => {
                     quote! {
                         #pat => {
-                            write_u64(w, 4, 2)?;
-                            write_u64(w, 0, #i as u64)?;
+                            write_u8(w, MajorKind::Array, 2)?;
+                            write_u64(w, MajorKind::UnsignedInt, #i as u64)?;
                             #value
                         }
                     }
@@ -208,7 +210,7 @@ fn gen_encode_union(u: &Union) -> TokenStream {
 }
 
 fn gen_decode_struct(s: &Struct) -> TokenStream {
-    let len = s.fields.len();
+    let len = s.fields.len() as u64;
     let construct = &*s.construct;
     match s.repr {
         StructRepr::Map => {
@@ -232,10 +234,10 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                 })
                 .collect();
             quote! {
-                let major = read_u8(r)?;
-                match major {
-                    0xa0..=0xbb => {
-                        let len = read_len(r, major - 0xa0)?;
+                let major = read_major(r)?;
+                match major.kind() {
+                    MajorKind::Map => {
+                        let len = read_uint(r, major)?;
                         if len > #len {
                             return Err(LengthOutOfRange::new::<Self>().into());
                         }
@@ -255,30 +257,8 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
 
                         return Ok(#construct);
                     }
-                    0xbf => {
-                        #(let mut #binding = None;)*
-                        loop {
-                            let major = read_u8(r)?;
-                            if major == 0xff {
-                                break;
-                            }
-                            r.seek(SeekFrom::Current(-1))?;
-                            let key = String::decode(c, r)?;
-                            match key.as_str() {
-                                #(#key => { #binding = Some(Decode::decode(c, r)?); })*
-                                _ => {
-                                    libipld::Ipld::decode(c, r)?;
-                                    //return Err(UnexpectedKey::new::<Self>(key).into()),
-                                }
-                            }
-                        }
-
-                        #(#fields)*
-
-                        return Ok(#construct);
-                    }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -291,10 +271,10 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                 }
             });
             quote! {
-                let major = read_u8(r)?;
-                match major {
-                    0x80..=0x9b => {
-                        let len = read_len(r, major - 0x80)?;
+                let major = read_major(r)?;
+                match major.kind() {
+                    MajorKind::Array => {
+                        let len = read_uint(r, major)?;
                         if len != #len {
                             return Err(LengthOutOfRange::new::<Self>().into());
                         }
@@ -302,7 +282,7 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
                         return Ok(#construct);
                     }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -318,13 +298,13 @@ fn gen_decode_struct(s: &Struct) -> TokenStream {
         StructRepr::Null => {
             assert_eq!(s.fields.len(), 0);
             quote! {
-                let major = read_u8(r)?;
+                let major = read_major(r)?;
                 match major {
-                    0xf6..=0xf7 => {
+                    NULL => {
                         return Ok(#construct);
                     }
                     _ => {
-                        return Err(UnexpectedCode::new::<Self>(major).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                 }
             }
@@ -345,9 +325,11 @@ fn gen_decode_union(u: &Union) -> TokenStream {
                 }
             });
             quote! {
-                let major = read_u8(r)?;
-                if major != 0xa1 {
-                    return Err(UnexpectedCode::new::<Self>(major).into());
+                let major = read_major(r)?;
+                if major.kind() != MajorKind::Map {
+                    return Err(UnexpectedCode::new::<Self>(major.into()).into());
+                } else if read_uint(r, major)? != 1 {
+                    return Err(LengthOutOfRange::new::<Self>().into());
                 }
                 let key: String = Decode::decode(c, r)?;
                 #(#variants;)*
@@ -355,6 +337,7 @@ fn gen_decode_union(u: &Union) -> TokenStream {
             }
         }
         UnionRepr::Kinded => {
+            // TODO: this is wrong. Kinded should be based on the kind, not "if it decodes".
             let variants = u.variants.iter().map(|s| {
                 let parse = gen_decode_struct(s);
                 quote! {
@@ -372,7 +355,7 @@ fn gen_decode_union(u: &Union) -> TokenStream {
             });
             quote! {
                 #(#variants;)*
-                Err(UnexpectedCode::new::<Self>(read_u8(r)?).into())
+                Err(UnexpectedCode::new::<Self>(read_major(r)?.into()).into())
             }
         }
         UnionRepr::String => {
@@ -406,15 +389,19 @@ fn gen_decode_union(u: &Union) -> TokenStream {
         }
         UnionRepr::IntTuple => {
             let variants = u.variants.iter().enumerate().map(|(i, s)| {
+                let i = i as u64;
                 let parse = gen_decode_struct(s);
                 quote!(#i => { #parse })
             });
             quote! {
-                let major = read_u8(r)?;
-                if major != 0x82 {
-                    return Err(UnexpectedCode::new::<Self>(major).into());
+                let major = read_major(r)?;
+                if major.kind() != MajorKind::Array {
+                    return Err(UnexpectedCode::new::<Self>(major.into()).into());
                 }
-                let ty = read_u8(r)? as usize;
+                if read_uint(r, major)? != 2 {
+                    return Err(LengthOutOfRange::new::<Self>().into());
+                }
+                let ty: u64 = Decode::decode(c, r)?;
                 match ty {
                     #(#variants,)*
                     _ => return Err(UnexpectedKey::new::<Self>(ty.to_string()).into()),

--- a/dag-cbor-derive/tests/struct.rs
+++ b/dag-cbor-derive/tests/struct.rs
@@ -1,5 +1,5 @@
 use libipld::cbor::{DagCbor, DagCborCodec};
-use libipld::codec::{assert_roundtrip, Codec};
+use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor};
 
 #[derive(Clone, Copy, DagCbor, Debug, Eq, PartialEq)]
@@ -151,22 +151,6 @@ pub struct IlMap {
     fun: bool,
     #[ipld(rename = "Amt")]
     amt: i32,
-}
-
-#[test]
-fn serde_cbor_compat() {
-    let bytes = [
-        0xBF, // Start indefinite-length map
-        0x63, // First key, UTF-8 string length 3
-        0x46, 0x75, 0x6e, // "Fun"
-        0xF5, // First value, true
-        0x63, // Second key, UTF-8 string length 3
-        0x41, 0x6d, 0x74, // "Amt"
-        0x21, // Second value, -2
-        0xFF, // "break"
-    ];
-    let il_map: IlMap = DagCborCodec.decode(&bytes).unwrap();
-    assert_eq!(il_map, IlMap { fun: true, amt: -2 });
 }
 
 #[derive(DagCbor)]

--- a/dag-cbor/src/cbor.rs
+++ b/dag-cbor/src/cbor.rs
@@ -1,0 +1,108 @@
+//! CBOR helper types for encoding and decoding.
+use std::convert::TryFrom;
+
+use crate::error::UnexpectedCode;
+use libipld_core::ipld::Ipld;
+
+/// Represents a major "byte". This includes both the major bits and the additional info.
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct Major(u8);
+
+/// The constant TRUE.
+pub const FALSE: Major = Major::new(MajorKind::Other, 20);
+/// The constant FALSE.
+pub const TRUE: Major = Major::new(MajorKind::Other, 21);
+/// The constant NULL.
+pub const NULL: Major = Major::new(MajorKind::Other, 22);
+/// The major "byte" indicating that a 16 bit float follows.
+pub const F16: Major = Major::new(MajorKind::Other, 25);
+/// The major "byte" indicating that a 32 bit float follows.
+pub const F32: Major = Major::new(MajorKind::Other, 26);
+/// The major "byte" indicating that a 64 bit float follows.
+pub const F64: Major = Major::new(MajorKind::Other, 27);
+
+impl Major {
+    const fn new(kind: MajorKind, info: u8) -> Self {
+        Major(((kind as u8) << 5) | info)
+    }
+
+    /// Returns the major type.
+    #[inline(always)]
+    pub const fn kind(self) -> MajorKind {
+        // This is a 3 bit value, so value 0-7 are covered.
+        unsafe { std::mem::transmute(self.0 >> 5) }
+    }
+
+    /// Returns the additional info.
+    #[inline(always)]
+    pub const fn info(self) -> u8 {
+        self.0 & 0x1f
+    }
+
+    /// Interprets the additioanl info as a number of additional bytes that should be consumed.
+    #[inline(always)]
+    #[allow(clippy::len_without_is_empty)]
+    pub const fn len(self) -> u8 {
+        // All major types follow the same rules for "additioanl bytes".
+        // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
+        match self.info() {
+            info @ 24..=27 => 1 << (info - 24),
+            _ => 0,
+        }
+    }
+}
+
+impl From<Major> for u8 {
+    fn from(m: Major) -> u8 {
+        m.0
+    }
+}
+
+// This is the core of the validation logic. Every major type passes through here giving us a chance
+// to determine if it's something we allow.
+impl TryFrom<u8> for Major {
+    type Error = UnexpectedCode;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        // We don't allow any major types with additional info 28-31 inclusive.
+        // Or the bitmask 0b00011100 = 28.
+        if value & 28 == 28 {
+            return Err(UnexpectedCode::new::<Ipld>(value));
+        } else if (value >> 5) == MajorKind::Other as u8 {
+            match value & 0x1f {
+                // False, True, Null. TODO: Allow undefined?
+                20 | 21 | 22 => (),
+                // Floats. TODO: forbid f16 & f32?
+                25 | 26 | 27 => (),
+                // Everything is forbidden.
+                _ => {
+                    return Err(UnexpectedCode::new::<Ipld>(value));
+                }
+            }
+        }
+        Ok(Major(value))
+    }
+}
+
+/// The type
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum MajorKind {
+    /// Non-negative integer (major type 0).
+    UnsignedInt = 0,
+    /// Negative integer (major type 1).
+    NegativeInt = 1,
+    /// Byte string (major type 2).
+    ByteString = 2,
+    /// Unicode text string (major type 3).
+    TextString = 3,
+    /// Array (major type 4).
+    Array = 4,
+    /// Map (major type 5).
+    Map = 5,
+    /// Tag (major type 6).
+    Tag = 6,
+    /// Other (major type 7).
+    Other = 7,
+}

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -1,7 +1,7 @@
 //! CBOR decoder
 use crate::error::{
-    IndefiniteLengthItem, InvalidCidPrefix, LengthOutOfRange, UnexpectedCode, UnexpectedEof,
-    UnknownTag,
+    InvalidCidPrefix, LengthOutOfRange, NumberNotMinimal, NumberOutOfRange, UnexpectedCode,
+    UnexpectedEof, UnknownTag,
 };
 use crate::DagCborCodec as DagCbor;
 use byteorder::{BigEndian, ByteOrder};
@@ -14,50 +14,132 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct Major(u8);
+
+impl Major {
+    const fn new(kind: MajorKind, info: u8) -> Self {
+        Major(((kind as u8) << 5) | info)
+    }
+
+    #[inline(always)]
+    const fn kind(self) -> MajorKind {
+        // This is a 3 bit value, so value 0-7 are covered.
+        unsafe { std::mem::transmute(self.0 >> 5) }
+    }
+
+    #[inline(always)]
+    const fn info(self) -> u8 {
+        self.0 & 0x1f
+    }
+
+    #[inline(always)]
+    const fn len(self) -> u8 {
+        // All major types follow the same rules for "additioanl bytes".
+        // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
+        match self.info() {
+            info @ 24..=27 => 1 << (info - 24),
+            _ => 0,
+        }
+    }
+}
+
+// This is the core of the validation logic. Every major type passes through here giving us a chance
+// to determine if it's something we allow.
+impl TryFrom<u8> for Major {
+    type Error = UnexpectedCode;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        // We don't allow any major types with additional info 28-31 inclusive.
+        // Or the bitmask 0b00011100 = 28.
+        if value & 28 == 28 {
+            return Err(UnexpectedCode::new::<Ipld>(value));
+        } else if (value >> 5) == MajorKind::Other as u8 {
+            match value & 0x1f {
+                // False, True, Null. TODO: Allow undefined?
+                20 | 21 | 22 => (),
+                // Floats. TODO: forbid f16 & f32?
+                25 | 26 | 27 => (),
+                // Everything is forbidden.
+                _ => {
+                    return Err(UnexpectedCode::new::<Ipld>(value));
+                }
+            }
+        }
+        Ok(Major(value))
+    }
+}
+
+mod consts {
+    use super::Major;
+    use super::MajorKind::*;
+
+    pub(super) const FALSE: Major = Major::new(Other, 20);
+    pub(super) const TRUE: Major = Major::new(Other, 21);
+    pub(super) const NULL: Major = Major::new(Other, 22);
+    pub(super) const F32: Major = Major::new(Other, 26);
+    pub(super) const F64: Major = Major::new(Other, 27);
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[allow(dead_code)]
+enum MajorKind {
+    UnsignedInt = 0,
+    NegativeInt = 1,
+    ByteString = 2,
+    TextString = 3,
+    Array = 4,
+    Map = 5,
+    Tag = 6,
+    Other = 7,
+}
+
 /// Reads a u8 from a byte stream.
-pub fn read_u8<R: Read + Seek>(r: &mut R) -> Result<u8> {
+pub fn read_u8<R: Read>(r: &mut R) -> Result<u8> {
     let mut buf = [0; 1];
     r.read_exact(&mut buf)?;
     Ok(buf[0])
 }
 
 /// Reads a u16 from a byte stream.
-pub fn read_u16<R: Read + Seek>(r: &mut R) -> Result<u16> {
+pub fn read_u16<R: Read>(r: &mut R) -> Result<u16> {
     let mut buf = [0; 2];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u16(&buf))
 }
 
 /// Reads a u32 from a byte stream.
-pub fn read_u32<R: Read + Seek>(r: &mut R) -> Result<u32> {
+pub fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
     let mut buf = [0; 4];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u32(&buf))
 }
 
 /// Reads a u64 from a byte stream.
-pub fn read_u64<R: Read + Seek>(r: &mut R) -> Result<u64> {
+pub fn read_u64<R: Read>(r: &mut R) -> Result<u64> {
     let mut buf = [0; 8];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_u64(&buf))
 }
 
 /// Reads a f32 from a byte stream.
-pub fn read_f32<R: Read + Seek>(r: &mut R) -> Result<f32> {
+pub fn read_f32<R: Read>(r: &mut R) -> Result<f32> {
     let mut buf = [0; 4];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_f32(&buf))
 }
 
 /// Reads a f64 from a byte stream.
-pub fn read_f64<R: Read + Seek>(r: &mut R) -> Result<f64> {
+pub fn read_f64<R: Read>(r: &mut R) -> Result<f64> {
     let mut buf = [0; 8];
     r.read_exact(&mut buf)?;
     Ok(BigEndian::read_f64(&buf))
 }
 
 /// Reads `len` number of bytes from a byte stream.
-pub fn read_bytes<R: Read + Seek>(r: &mut R, len: usize) -> Result<Vec<u8>> {
+pub fn read_bytes<R: Read>(r: &mut R, len: u64) -> Result<Vec<u8>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     // Limit up-front allocations to 16KiB as the length is user controlled.
     let mut buf = Vec::with_capacity(len.min(16 * 1024));
     r.take(len as u64).read_to_end(&mut buf)?;
@@ -68,13 +150,14 @@ pub fn read_bytes<R: Read + Seek>(r: &mut R, len: usize) -> Result<Vec<u8>> {
 }
 
 /// Reads `len` number of bytes from a byte stream and converts them to a string.
-pub fn read_str<R: Read + Seek>(r: &mut R, len: usize) -> Result<String> {
+pub fn read_str<R: Read>(r: &mut R, len: u64) -> Result<String> {
     let bytes = read_bytes(r, len)?;
     Ok(String::from_utf8(bytes)?)
 }
 
 /// Reads a list of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
-pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: usize) -> Result<Vec<T>> {
+pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: u64) -> Result<Vec<T>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     // Limit up-front allocations to 16KiB as the length is user controlled.
     //
     // Can't make this "const" because the generic, but it _should_ be known at compile time.
@@ -90,8 +173,9 @@ pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: usize) -> R
 /// Reads a map of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
 pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
     r: &mut R,
-    len: usize,
+    len: u64,
 ) -> Result<BTreeMap<K, T>> {
+    let len = usize::try_from(len).map_err(|_| LengthOutOfRange::new::<usize>())?;
     let mut map: BTreeMap<K, T> = BTreeMap::new();
     for _ in 0..len {
         let key = K::decode(DagCbor, r)?;
@@ -103,258 +187,198 @@ pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
 
 /// Reads a cid from a stream of cbor encoded bytes.
 pub fn read_link<R: Read + Seek>(r: &mut R) -> Result<Cid> {
-    let ty = read_u8(r)?;
-    if ty != 0x58 {
-        return Err(UnknownTag(ty).into());
+    let major = read_major(r)?;
+    if major.kind() != MajorKind::ByteString {
+        return Err(UnexpectedCode::new::<Cid>(major.0).into());
     }
-    let len = read_u8(r)?;
-    if len == 0 {
+    let len = read_uint(r, major)?;
+    if len < 1 {
         return Err(LengthOutOfRange::new::<Cid>().into());
     }
-    let bytes = read_bytes(r, len as usize)?;
-    if bytes[0] != 0 {
-        return Err(InvalidCidPrefix(bytes[0]).into());
-    }
+
+    let mut r = r.take(len);
 
     // skip the first byte per
     // https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#links
-    Ok(Cid::try_from(&bytes[1..])?)
+    let prefix = read_u8(&mut r)?;
+    if prefix != 0 {
+        return Err(InvalidCidPrefix(prefix).into());
+    }
+
+    // Read the CID. No need to limit the size, the CID will do this for us.
+    let cid = Cid::read_bytes(&mut r)?;
+
+    // Make sure we've read the entire CID.
+    if r.read(&mut [0u8][..])? != 0 {
+        return Err(LengthOutOfRange::new::<Cid>().into());
+    }
+
+    Ok(cid)
 }
 
-/// Reads the len given a base.
-pub fn read_len<R: Read + Seek>(r: &mut R, major: u8) -> Result<usize> {
-    Ok(match major {
-        0x00..=0x17 => major as usize,
-        0x18 => read_u8(r)? as usize,
-        0x19 => read_u16(r)? as usize,
-        0x1a => read_u32(r)? as usize,
-        0x1b => {
-            let len = read_u64(r)?;
-            if len > usize::max_value() as u64 {
-                return Err(LengthOutOfRange::new::<usize>().into());
-            }
-            len as usize
-        }
-        major => return Err(UnexpectedCode::new::<usize>(major).into()),
-    })
+fn read_major<R: Read>(r: &mut R) -> Result<Major> {
+    Ok(Major::try_from(read_u8(r)?)?)
+}
+
+fn read_uint<R: Read>(r: &mut R, major: Major) -> Result<u64> {
+    const MAX_SHORT: u64 = 23;
+    const MAX_1BYTE: u64 = u8::MAX as u64;
+    const MAX_2BYTE: u64 = u16::MAX as u64;
+    const MAX_4BYTE: u64 = u32::MAX as u64;
+    match major.info() {
+        value @ 0..=23 => Ok(value as u64),
+        24 => match read_u8(r)? as u64 {
+            0..=MAX_SHORT => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        25 => match read_u16(r)? as u64 {
+            0..=MAX_1BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        26 => match read_u32(r)? as u64 {
+            0..=MAX_2BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        27 => match read_u64(r)? as u64 {
+            0..=MAX_4BYTE => Err(NumberNotMinimal.into()),
+            value => Ok(value),
+        },
+        _ => Err(UnexpectedCode::new::<usize>(major.0).into()),
+    }
 }
 
 impl Decode<DagCbor> for bool {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xf4 => false,
-            0xf5 => true,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        Ok(match read_major(r)? {
+            consts::FALSE => false,
+            consts::TRUE => true,
+            Major(n) => return Err(UnexpectedCode::new::<Self>(n).into()),
+        })
     }
 }
 
-impl Decode<DagCbor> for u8 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major,
-            0x18 => read_u8(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
+macro_rules! impl_num {
+    (unsigned $($t:ty),*) => {
+        $(
+            impl Decode<DagCbor> for $t {
+                fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
+                    let major = read_major(r)?;
+                    if major.kind() != MajorKind::UnsignedInt {
+                        return Err(UnexpectedCode::new::<Self>(major.0).into());
+                    }
+                    let value = read_uint(r, major)?;
+                    Self::try_from(value).map_err(|_| NumberOutOfRange::new::<Self>().into())
+                }
             }
-        };
-        Ok(result)
-    }
+        )*
+    };
+    (signed $($t:ty),*) => {
+        $(
+            impl Decode<DagCbor> for $t {
+                fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
+                    let major = read_major(r)?;
+                    let value = read_uint(r, major)?;
+                    match major.kind() {
+                        MajorKind::UnsignedInt | MajorKind::NegativeInt => (),
+                        _ => return Err(UnexpectedCode::new::<Self>(major.0).into()),
+                    };
+
+                    let mut value = Self::try_from(value)
+                        .map_err(|_| NumberOutOfRange::new::<Self>())?;
+                    if major.kind() == MajorKind::NegativeInt {
+                        // This is guaranteed to not overflow.
+                        value = -1 - value;
+                    }
+                    Ok(value)
+                }
+            }
+        )*
+    };
 }
 
-impl Decode<DagCbor> for u16 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u16,
-            0x18 => read_u8(r)? as u16,
-            0x19 => read_u16(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for u32 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u32,
-            0x18 => read_u8(r)? as u32,
-            0x19 => read_u16(r)? as u32,
-            0x1a => read_u32(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for u64 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x00..=0x17 => major as u64,
-            0x18 => read_u8(r)? as u64,
-            0x19 => read_u16(r)? as u64,
-            0x1a => read_u32(r)? as u64,
-            0x1b => read_u64(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i8 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i8,
-            0x38 => -1 - read_u8(r)? as i8,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i16 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i16,
-            0x38 => -1 - read_u8(r)? as i16,
-            0x39 => -1 - read_u16(r)? as i16,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i32 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i32,
-            0x38 => -1 - read_u8(r)? as i32,
-            0x39 => -1 - read_u16(r)? as i32,
-            0x3a => -1 - read_u32(r)? as i32,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
-
-impl Decode<DagCbor> for i64 {
-    fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x20..=0x37 => -1 - (major - 0x20) as i64,
-            0x38 => -1 - read_u8(r)? as i64,
-            0x39 => -1 - read_u16(r)? as i64,
-            0x3a => -1 - read_u32(r)? as i64,
-            0x3b => -1 - read_u64(r)? as i64,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
-    }
-}
+impl_num!(unsigned u8, u16, u32, u64, u128);
+impl_num!(signed i8, i16, i32, i64, i128);
 
 impl Decode<DagCbor> for f32 {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xfa => read_f32(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
+        // TODO: We don't accept f16
+        // TODO: By IPLD spec, we shouldn't accept f32 either...
+        let num = match read_major(r)? {
+            consts::F32 => f32::from_bits(read_u32(r)?),
+            consts::F64 => {
+                let num = f64::from_bits(read_u64(r)?);
+                let converted = num as Self;
+                if f64::from(converted) != num {
+                    return Err(NumberOutOfRange::new::<Self>().into());
+                }
+                converted
             }
+            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
         };
-        Ok(result)
+        if !num.is_finite() {
+            return Err(NumberOutOfRange::new::<Self>().into());
+        }
+        Ok(num)
     }
 }
 
 impl Decode<DagCbor> for f64 {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xfa => read_f32(r)? as f64,
-            0xfb => read_f64(r)?,
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
+        // TODO: We don't accept f16
+        // TODO: By IPLD spec, we shouldn't accept f32 either...
+        let num = match read_major(r)? {
+            consts::F32 => f32::from_bits(read_u32(r)?).into(),
+            consts::F64 => f64::from_bits(read_u64(r)?),
+            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
         };
-        Ok(result)
+        // This is by IPLD spec, but is it widely used?
+        if !num.is_finite() {
+            return Err(NumberOutOfRange::new::<Self>().into());
+        }
+        Ok(num)
     }
 }
 
 impl Decode<DagCbor> for String {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                read_str(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::TextString {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        read_str(r, len)
     }
 }
 
 impl Decode<DagCbor> for Cid {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        if major == 0xd8 {
-            if let Ok(tag) = read_u8(r) {
-                if tag == 42 {
-                    return read_link(r);
-                }
+        let major = read_major(r)?;
+        if major.kind() == MajorKind::Tag {
+            match read_uint(r, major)? {
+                42 => read_link(r),
+                tag => Err(UnknownTag(tag).into()),
             }
+        } else {
+            Err(UnexpectedCode::new::<Self>(major.0).into())
         }
-        Err(UnexpectedCode::new::<Self>(major).into())
     }
 }
 
 impl Decode<DagCbor> for Box<[u8]> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                read_bytes(r, len)?.into_boxed_slice()
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::ByteString {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        Ok(read_bytes(r, len)?.into_boxed_slice())
     }
 }
 
 impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
     fn decode<R: Read + Seek>(c: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xf6 => None,
+        let result = match read_major(r)? {
+            consts::NULL => None,
             _ => {
                 r.seek(SeekFrom::Current(-1))?;
                 Some(T::decode(c, r)?)
@@ -366,99 +390,65 @@ impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
 
 impl<T: Decode<DagCbor>> Decode<DagCbor> for Vec<T> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                read_list(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::Array {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+        let len = read_uint(r, major)?;
+        read_list(r, len)
     }
 }
 
 impl<K: Decode<DagCbor> + Ord, T: Decode<DagCbor>> Decode<DagCbor> for BTreeMap<K, T> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let result = match major {
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                read_map(r, len)?
-            }
-            _ => {
-                return Err(UnexpectedCode::new::<Self>(major).into());
-            }
-        };
-        Ok(result)
+        let major = read_major(r)?;
+        if major.kind() != MajorKind::Map {
+            return Err(UnexpectedCode::new::<Self>(major.0).into());
+        }
+
+        let len = read_uint(r, major)?;
+        read_map(r, len)
     }
 }
 
 impl Decode<DagCbor> for Ipld {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
-        let major = read_u8(r)?;
-        let ipld = match major {
-            // Major type 0: an unsigned integer
-            0x00..=0x17 => Self::Integer(major as i128),
-            0x18 => Self::Integer(read_u8(r)? as i128),
-            0x19 => Self::Integer(read_u16(r)? as i128),
-            0x1a => Self::Integer(read_u32(r)? as i128),
-            0x1b => Self::Integer(read_u64(r)? as i128),
-
-            // Major type 1: a negative integer
-            0x20..=0x37 => Self::Integer(-1 - (major - 0x20) as i128),
-            0x38 => Self::Integer(-1 - read_u8(r)? as i128),
-            0x39 => Self::Integer(-1 - read_u16(r)? as i128),
-            0x3a => Self::Integer(-1 - read_u32(r)? as i128),
-            0x3b => Self::Integer(-1 - read_u64(r)? as i128),
-
-            // Major type 2: a byte string
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                let bytes = read_bytes(r, len as usize)?;
-                Self::Bytes(bytes)
+        let major = read_major(r)?;
+        let ipld = match major.kind() {
+            MajorKind::UnsignedInt => Self::Integer(read_uint(r, major)? as i128),
+            MajorKind::NegativeInt => Self::Integer(-1 - read_uint(r, major)? as i128),
+            MajorKind::ByteString => {
+                let len = read_uint(r, major)?;
+                Self::Bytes(read_bytes(r, len)?)
             }
-
-            // Major type 3: a text string
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                let string = read_str(r, len as usize)?;
-                Self::String(string)
+            MajorKind::TextString => {
+                let len = read_uint(r, major)?;
+                Self::String(read_str(r, len)?)
             }
-
-            // Major type 4: an array of data items
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                let list = read_list(r, len as usize)?;
-                Self::List(list)
+            MajorKind::Array => {
+                let len = read_uint(r, major)?;
+                Self::List(read_list(r, len)?)
             }
-
-            // Major type 5: a map of pairs of data items
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                Self::Map(read_map(r, len as usize)?)
+            MajorKind::Map => {
+                let len = read_uint(r, major)?;
+                Self::Map(read_map(r, len)?)
             }
-
-            // Major type 6: optional semantic tagging of other major types
-            0xd8 => {
-                let tag = read_u8(r)?;
-                if tag == 42 {
+            MajorKind::Tag => {
+                let value = read_uint(r, major)?;
+                if value == 42 {
                     Self::Link(read_link(r)?)
                 } else {
-                    return Err(UnknownTag(tag).into());
+                    return Err(UnknownTag(value).into());
                 }
             }
-
-            // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4 => Self::Bool(false),
-            0xf5 => Self::Bool(true),
-            0xf6 => Self::Null,
-            0xfa => Self::Float(read_f32(r)? as f64),
-            0xfb => Self::Float(read_f64(r)?),
-            0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
-            _ => return Err(UnexpectedCode::new::<Self>(major).into()),
+            MajorKind::Other => match major {
+                consts::FALSE => Self::Bool(false),
+                consts::TRUE => Self::Bool(true),
+                consts::NULL => Self::Null,
+                consts::F32 => Self::Float(f32::from_bits(read_u32(r)?).into()),
+                consts::F64 => Self::Float(f64::from_bits(read_u64(r)?)),
+                Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
+            },
         };
         Ok(ipld)
     }
@@ -470,102 +460,49 @@ impl References<DagCbor> for Ipld {
         r: &mut R,
         set: &mut E,
     ) -> Result<()> {
-        let mut remaining: usize = 1;
+        let mut remaining: u64 = 1;
         while remaining > 0 {
-            let major = read_u8(r)?;
-            match major {
-                // Major type 0: an unsigned integer
-                0x00..=0x17 => {}
-                0x18 => {
-                    r.seek(SeekFrom::Current(1))?;
+            remaining -= 1;
+            let major = read_major(r)?;
+            match major.kind() {
+                MajorKind::UnsignedInt | MajorKind::NegativeInt | MajorKind::Other => {
+                    // TODO: validate ints & floats?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
                 }
-                0x19 => {
-                    r.seek(SeekFrom::Current(2))?;
+                MajorKind::ByteString | MajorKind::TextString => {
+                    // TODO: validate utf8?
+                    // We could just reject this case, but we can't just play it fast and loose and
+                    // wrap. We might as well just try to seek (and likely fail).
+                    let mut offset = read_uint(r, major)?;
+                    while offset > i64::MAX as u64 {
+                        r.seek(SeekFrom::Current(i64::MAX))?;
+                        offset -= i64::MAX as u64;
+                    }
+                    r.seek(SeekFrom::Current(offset as i64))?;
                 }
-                0x1a => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0x1b => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-
-                // Major type 1: a negative integer
-                0x20..=0x37 => {}
-                0x38 => {
-                    r.seek(SeekFrom::Current(1))?;
-                }
-                0x39 => {
-                    r.seek(SeekFrom::Current(2))?;
-                }
-                0x3a => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0x3b => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-
-                // Major type 2: a byte string
-                0x40..=0x5b => {
-                    let len = read_len(r, major - 0x40)?;
-                    r.seek(SeekFrom::Current(len as _))?;
-                }
-
-                // Major type 3: a text string
-                0x60..=0x7b => {
-                    let len = read_len(r, major - 0x60)?;
-                    r.seek(SeekFrom::Current(len as _))?;
-                }
-
-                // Major type 4: an array of data items
-                0x80..=0x9b => {
-                    let len = read_len(r, major - 0x80)?;
+                MajorKind::Array => {
                     remaining = remaining
-                        .checked_add(len)
+                        .checked_add(read_uint(r, major)?)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                 }
-
-                // Major type 5: a map of pairs of data items
-                0xa0..=0xbb => {
-                    let len = read_len(r, major - 0xa0)?;
+                MajorKind::Map => {
                     // TODO: consider using a checked "monad" type to simplify.
-                    let items = len
+                    let items = read_uint(r, major)?
                         .checked_mul(2)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                     remaining = remaining
                         .checked_add(items)
                         .ok_or_else(LengthOutOfRange::new::<Self>)?;
                 }
-
-                // Major type 6: optional semantic tagging of other major types
-                0xd8 => {
-                    let tag = read_u8(r)?;
-                    if tag == 42 {
-                        set.extend(std::iter::once(read_link(r)?));
-                    } else {
+                MajorKind::Tag => match read_uint(r, major)? {
+                    42 => set.extend(std::iter::once(read_link(r)?)),
+                    _ => {
                         remaining = remaining
                             .checked_add(1)
                             .ok_or_else(LengthOutOfRange::new::<Self>)?;
                     }
-                }
-
-                // Major type 7: floating-point numbers and other simple data types that need no content
-                0xf4..=0xf7 => {}
-                0xf8 => {
-                    r.seek(SeekFrom::Current(1))?;
-                }
-                0xf9 => {
-                    r.seek(SeekFrom::Current(2))?;
-                }
-                0xfa => {
-                    r.seek(SeekFrom::Current(4))?;
-                }
-                0xfb => {
-                    r.seek(SeekFrom::Current(8))?;
-                }
-                0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
-                major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
+                },
             };
-            remaining -= 1;
         }
         Ok(())
     }
@@ -651,106 +588,50 @@ impl<A: Decode<DagCbor>, B: Decode<DagCbor>, C: Decode<DagCbor>, D: Decode<DagCb
 
 impl SkipOne for DagCbor {
     fn skip<R: Read + Seek>(&self, r: &mut R) -> Result<()> {
-        let major = read_u8(r)?;
-        match major {
-            // Major type 0: an unsigned integer
-            0x00..=0x17 => {}
-            0x18 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x19 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x1a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x1b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 1: a negative integer
-            0x20..=0x37 => {}
-            0x38 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x39 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x3a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x3b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 2: a byte string
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 3: a text string
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 4: an array of data items
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                for _ in 0..len {
-                    self.skip(r)?;
+        let mut remaining: u64 = 1;
+        while remaining > 0 {
+            remaining -= 1;
+            let major = read_major(r)?;
+            match major.kind() {
+                MajorKind::UnsignedInt | MajorKind::NegativeInt | MajorKind::Other => {
+                    // TODO: validate?
+                    // minimal integer, valid float, etc?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
                 }
-            }
-
-            // Major type 5: a map of pairs of data items
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                for _ in 0..len {
-                    self.skip(r)?;
-                    self.skip(r)?;
+                MajorKind::ByteString | MajorKind::TextString => {
+                    // We could just reject this case, but we can't just play it fast and loose and
+                    // wrap. We might as well just try to seek (and likely fail).
+                    let mut offset = read_uint(r, major)?;
+                    while offset > i64::MAX as u64 {
+                        r.seek(SeekFrom::Current(i64::MAX))?;
+                        offset -= i64::MAX as u64;
+                    }
+                    // TODO: validate utf8?
+                    r.seek(SeekFrom::Current(offset as i64))?;
                 }
-            }
-
-            // Major type 6: optional semantic tagging of other major types
-            0xc0..=0xd7 => {
-                // let _tag = major - 0xc0;
-                self.skip(r)?;
-            }
-            0xd8 => {
-                r.seek(SeekFrom::Current(1))?;
-                self.skip(r)?;
-            }
-
-            0xd9 => {
-                r.seek(SeekFrom::Current(2))?;
-                self.skip(r)?;
-            }
-            0xda => {
-                r.seek(SeekFrom::Current(4))?;
-                self.skip(r)?;
-            }
-            0xdb => {
-                r.seek(SeekFrom::Current(8))?;
-                self.skip(r)?;
-            }
-
-            // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4..=0xf7 => {}
-            0xf8 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0xf9 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0xfa => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0xfb => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-            major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
-        };
+                MajorKind::Array => {
+                    remaining = remaining
+                        .checked_add(read_uint(r, major)?)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+                MajorKind::Map => {
+                    // TODO: consider using a checked "monad" type to simplify.
+                    let items = read_uint(r, major)?
+                        .checked_mul(2)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                    remaining = remaining
+                        .checked_add(items)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+                MajorKind::Tag => {
+                    // TODO: validate tag?
+                    r.seek(SeekFrom::Current(major.len() as i64))?;
+                    remaining = remaining
+                        .checked_add(1)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+            };
+        }
         Ok(())
     }
 }

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -1,4 +1,5 @@
 //! CBOR decoder
+use crate::cbor::{Major, MajorKind, F32, F64, FALSE, NULL, TRUE};
 use crate::error::{
     InvalidCidPrefix, LengthOutOfRange, NumberNotMinimal, NumberOutOfRange, UnexpectedCode,
     UnexpectedEof, UnknownTag,
@@ -13,87 +14,6 @@ use libipld_core::{cid::Cid, raw_value::SkipOne};
 use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Eq, PartialEq)]
-struct Major(u8);
-
-impl Major {
-    const fn new(kind: MajorKind, info: u8) -> Self {
-        Major(((kind as u8) << 5) | info)
-    }
-
-    #[inline(always)]
-    const fn kind(self) -> MajorKind {
-        // This is a 3 bit value, so value 0-7 are covered.
-        unsafe { std::mem::transmute(self.0 >> 5) }
-    }
-
-    #[inline(always)]
-    const fn info(self) -> u8 {
-        self.0 & 0x1f
-    }
-
-    #[inline(always)]
-    const fn len(self) -> u8 {
-        // All major types follow the same rules for "additioanl bytes".
-        // 24 -> 1, 25 -> 2, 26 -> 4, 27 -> 8
-        match self.info() {
-            info @ 24..=27 => 1 << (info - 24),
-            _ => 0,
-        }
-    }
-}
-
-// This is the core of the validation logic. Every major type passes through here giving us a chance
-// to determine if it's something we allow.
-impl TryFrom<u8> for Major {
-    type Error = UnexpectedCode;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        // We don't allow any major types with additional info 28-31 inclusive.
-        // Or the bitmask 0b00011100 = 28.
-        if value & 28 == 28 {
-            return Err(UnexpectedCode::new::<Ipld>(value));
-        } else if (value >> 5) == MajorKind::Other as u8 {
-            match value & 0x1f {
-                // False, True, Null. TODO: Allow undefined?
-                20 | 21 | 22 => (),
-                // Floats. TODO: forbid f16 & f32?
-                25 | 26 | 27 => (),
-                // Everything is forbidden.
-                _ => {
-                    return Err(UnexpectedCode::new::<Ipld>(value));
-                }
-            }
-        }
-        Ok(Major(value))
-    }
-}
-
-mod consts {
-    use super::Major;
-    use super::MajorKind::*;
-
-    pub(super) const FALSE: Major = Major::new(Other, 20);
-    pub(super) const TRUE: Major = Major::new(Other, 21);
-    pub(super) const NULL: Major = Major::new(Other, 22);
-    pub(super) const F32: Major = Major::new(Other, 26);
-    pub(super) const F64: Major = Major::new(Other, 27);
-}
-
-#[repr(u8)]
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[allow(dead_code)]
-enum MajorKind {
-    UnsignedInt = 0,
-    NegativeInt = 1,
-    ByteString = 2,
-    TextString = 3,
-    Array = 4,
-    Map = 5,
-    Tag = 6,
-    Other = 7,
-}
 
 /// Reads a u8 from a byte stream.
 pub fn read_u8<R: Read>(r: &mut R) -> Result<u8> {
@@ -189,7 +109,7 @@ pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
 pub fn read_link<R: Read + Seek>(r: &mut R) -> Result<Cid> {
     let major = read_major(r)?;
     if major.kind() != MajorKind::ByteString {
-        return Err(UnexpectedCode::new::<Cid>(major.0).into());
+        return Err(UnexpectedCode::new::<Cid>(major.into()).into());
     }
     let len = read_uint(r, major)?;
     if len < 1 {
@@ -216,15 +136,22 @@ pub fn read_link<R: Read + Seek>(r: &mut R) -> Result<Cid> {
     Ok(cid)
 }
 
-fn read_major<R: Read>(r: &mut R) -> Result<Major> {
+/// Read a and validate major "byte". This includes both the major type and the additional info.
+pub fn read_major<R: Read>(r: &mut R) -> Result<Major> {
     Ok(Major::try_from(read_u8(r)?)?)
 }
 
-fn read_uint<R: Read>(r: &mut R, major: Major) -> Result<u64> {
+/// Read the uint argument to the given major type. This function errors if:
+/// 1. The major type doesn't expect an integer argument.
+/// 2. The integer argument is not "minimally" encoded per the IPLD spec.
+pub fn read_uint<R: Read>(r: &mut R, major: Major) -> Result<u64> {
     const MAX_SHORT: u64 = 23;
     const MAX_1BYTE: u64 = u8::MAX as u64;
     const MAX_2BYTE: u64 = u16::MAX as u64;
     const MAX_4BYTE: u64 = u32::MAX as u64;
+    if major.kind() == MajorKind::Other {
+        return Err(UnexpectedCode::new::<u64>(major.into()).into());
+    }
     match major.info() {
         value @ 0..=23 => Ok(value as u64),
         24 => match read_u8(r)? as u64 {
@@ -243,16 +170,16 @@ fn read_uint<R: Read>(r: &mut R, major: Major) -> Result<u64> {
             0..=MAX_4BYTE => Err(NumberNotMinimal.into()),
             value => Ok(value),
         },
-        _ => Err(UnexpectedCode::new::<usize>(major.0).into()),
+        _ => Err(UnexpectedCode::new::<u64>(major.into()).into()),
     }
 }
 
 impl Decode<DagCbor> for bool {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
         Ok(match read_major(r)? {
-            consts::FALSE => false,
-            consts::TRUE => true,
-            Major(n) => return Err(UnexpectedCode::new::<Self>(n).into()),
+            FALSE => false,
+            TRUE => true,
+            m => return Err(UnexpectedCode::new::<Self>(m.into()).into()),
         })
     }
 }
@@ -264,7 +191,7 @@ macro_rules! impl_num {
                 fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
                     let major = read_major(r)?;
                     if major.kind() != MajorKind::UnsignedInt {
-                        return Err(UnexpectedCode::new::<Self>(major.0).into());
+                        return Err(UnexpectedCode::new::<Self>(major.into()).into());
                     }
                     let value = read_uint(r, major)?;
                     Self::try_from(value).map_err(|_| NumberOutOfRange::new::<Self>().into())
@@ -280,7 +207,7 @@ macro_rules! impl_num {
                     let value = read_uint(r, major)?;
                     match major.kind() {
                         MajorKind::UnsignedInt | MajorKind::NegativeInt => (),
-                        _ => return Err(UnexpectedCode::new::<Self>(major.0).into()),
+                        _ => return Err(UnexpectedCode::new::<Self>(major.into()).into()),
                     };
 
                     let mut value = Self::try_from(value)
@@ -304,16 +231,16 @@ impl Decode<DagCbor> for f32 {
         // TODO: We don't accept f16
         // TODO: By IPLD spec, we shouldn't accept f32 either...
         let num = match read_major(r)? {
-            consts::F32 => f32::from_bits(read_u32(r)?),
-            consts::F64 => {
-                let num = f64::from_bits(read_u64(r)?);
+            F32 => read_f32(r)?,
+            F64 => {
+                let num = read_f64(r)?;
                 let converted = num as Self;
                 if f64::from(converted) != num {
                     return Err(NumberOutOfRange::new::<Self>().into());
                 }
                 converted
             }
-            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
+            m => return Err(UnexpectedCode::new::<Self>(m.into()).into()),
         };
         if !num.is_finite() {
             return Err(NumberOutOfRange::new::<Self>().into());
@@ -327,9 +254,9 @@ impl Decode<DagCbor> for f64 {
         // TODO: We don't accept f16
         // TODO: By IPLD spec, we shouldn't accept f32 either...
         let num = match read_major(r)? {
-            consts::F32 => f32::from_bits(read_u32(r)?).into(),
-            consts::F64 => f64::from_bits(read_u64(r)?),
-            Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
+            F32 => read_f32(r)?.into(),
+            F64 => read_f64(r)?,
+            m => return Err(UnexpectedCode::new::<Self>(m.into()).into()),
         };
         // This is by IPLD spec, but is it widely used?
         if !num.is_finite() {
@@ -343,7 +270,7 @@ impl Decode<DagCbor> for String {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
         let major = read_major(r)?;
         if major.kind() != MajorKind::TextString {
-            return Err(UnexpectedCode::new::<Self>(major.0).into());
+            return Err(UnexpectedCode::new::<Self>(major.into()).into());
         }
         let len = read_uint(r, major)?;
         read_str(r, len)
@@ -359,7 +286,7 @@ impl Decode<DagCbor> for Cid {
                 tag => Err(UnknownTag(tag).into()),
             }
         } else {
-            Err(UnexpectedCode::new::<Self>(major.0).into())
+            Err(UnexpectedCode::new::<Self>(major.into()).into())
         }
     }
 }
@@ -368,7 +295,7 @@ impl Decode<DagCbor> for Box<[u8]> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
         let major = read_major(r)?;
         if major.kind() != MajorKind::ByteString {
-            return Err(UnexpectedCode::new::<Self>(major.0).into());
+            return Err(UnexpectedCode::new::<Self>(major.into()).into());
         }
         let len = read_uint(r, major)?;
         Ok(read_bytes(r, len)?.into_boxed_slice())
@@ -378,7 +305,7 @@ impl Decode<DagCbor> for Box<[u8]> {
 impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
     fn decode<R: Read + Seek>(c: DagCbor, r: &mut R) -> Result<Self> {
         let result = match read_major(r)? {
-            consts::NULL => None,
+            NULL => None,
             _ => {
                 r.seek(SeekFrom::Current(-1))?;
                 Some(T::decode(c, r)?)
@@ -392,7 +319,7 @@ impl<T: Decode<DagCbor>> Decode<DagCbor> for Vec<T> {
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
         let major = read_major(r)?;
         if major.kind() != MajorKind::Array {
-            return Err(UnexpectedCode::new::<Self>(major.0).into());
+            return Err(UnexpectedCode::new::<Self>(major.into()).into());
         }
         let len = read_uint(r, major)?;
         read_list(r, len)
@@ -403,7 +330,7 @@ impl<K: Decode<DagCbor> + Ord, T: Decode<DagCbor>> Decode<DagCbor> for BTreeMap<
     fn decode<R: Read + Seek>(_: DagCbor, r: &mut R) -> Result<Self> {
         let major = read_major(r)?;
         if major.kind() != MajorKind::Map {
-            return Err(UnexpectedCode::new::<Self>(major.0).into());
+            return Err(UnexpectedCode::new::<Self>(major.into()).into());
         }
 
         let len = read_uint(r, major)?;
@@ -442,12 +369,12 @@ impl Decode<DagCbor> for Ipld {
                 }
             }
             MajorKind::Other => match major {
-                consts::FALSE => Self::Bool(false),
-                consts::TRUE => Self::Bool(true),
-                consts::NULL => Self::Null,
-                consts::F32 => Self::Float(f32::from_bits(read_u32(r)?).into()),
-                consts::F64 => Self::Float(f64::from_bits(read_u64(r)?)),
-                Major(v) => return Err(UnexpectedCode::new::<Self>(v).into()),
+                FALSE => Self::Bool(false),
+                TRUE => Self::Bool(true),
+                NULL => Self::Null,
+                F32 => Self::Float(read_f32(r)? as f64),
+                F64 => Self::Float(read_f64(r)?),
+                m => return Err(UnexpectedCode::new::<Self>(m.into()).into()),
             },
         };
         Ok(ipld)

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -1,5 +1,8 @@
 //! CBOR decoder
-use crate::error::{InvalidCidPrefix, LengthOutOfRange, UnexpectedCode, UnexpectedEof, UnknownTag};
+use crate::error::{
+    IndefiniteLengthItem, InvalidCidPrefix, LengthOutOfRange, UnexpectedCode, UnexpectedEof,
+    UnknownTag,
+};
 use crate::DagCborCodec as DagCbor;
 use byteorder::{BigEndian, ByteOrder};
 use core::convert::TryFrom;
@@ -84,21 +87,6 @@ pub fn read_list<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R, len: usize) -> R
     Ok(list)
 }
 
-/// Reads a list of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
-pub fn read_list_il<R: Read + Seek, T: Decode<DagCbor>>(r: &mut R) -> Result<Vec<T>> {
-    let mut list: Vec<T> = Vec::new();
-    loop {
-        let major = read_u8(r)?;
-        if major == 0xff {
-            break;
-        }
-        r.seek(SeekFrom::Current(-1))?;
-        let value = T::decode(DagCbor, r)?;
-        list.push(value);
-    }
-    Ok(list)
-}
-
 /// Reads a map of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
 pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
     r: &mut R,
@@ -106,24 +94,6 @@ pub fn read_map<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
 ) -> Result<BTreeMap<K, T>> {
     let mut map: BTreeMap<K, T> = BTreeMap::new();
     for _ in 0..len {
-        let key = K::decode(DagCbor, r)?;
-        let value = T::decode(DagCbor, r)?;
-        map.insert(key, value);
-    }
-    Ok(map)
-}
-
-/// Reads a map of any type that implements `TryReadCbor` from a stream of cbor encoded bytes.
-pub fn read_map_il<R: Read + Seek, K: Decode<DagCbor> + Ord, T: Decode<DagCbor>>(
-    r: &mut R,
-) -> Result<BTreeMap<K, T>> {
-    let mut map: BTreeMap<K, T> = BTreeMap::new();
-    loop {
-        let major = read_u8(r)?;
-        if major == 0xff {
-            break;
-        }
-        r.seek(SeekFrom::Current(-1))?;
         let key = K::decode(DagCbor, r)?;
         let value = T::decode(DagCbor, r)?;
         map.insert(key, value);
@@ -385,7 +355,6 @@ impl<T: Decode<DagCbor>> Decode<DagCbor> for Option<T> {
         let major = read_u8(r)?;
         let result = match major {
             0xf6 => None,
-            0xf7 => None,
             _ => {
                 r.seek(SeekFrom::Current(-1))?;
                 Some(T::decode(c, r)?)
@@ -403,7 +372,6 @@ impl<T: Decode<DagCbor>> Decode<DagCbor> for Vec<T> {
                 let len = read_len(r, major - 0x80)?;
                 read_list(r, len)?
             }
-            0x9f => read_list_il(r)?,
             _ => {
                 return Err(UnexpectedCode::new::<Self>(major).into());
             }
@@ -420,7 +388,6 @@ impl<K: Decode<DagCbor> + Ord, T: Decode<DagCbor>> Decode<DagCbor> for BTreeMap<
                 let len = read_len(r, major - 0xa0)?;
                 read_map(r, len)?
             }
-            0xbf => read_map_il(r)?,
             _ => {
                 return Err(UnexpectedCode::new::<Self>(major).into());
             }
@@ -468,23 +435,10 @@ impl Decode<DagCbor> for Ipld {
                 Self::List(list)
             }
 
-            // Major type 4: an array of data items (indefinite length)
-            0x9f => {
-                let list = read_list_il(r)?;
-                Self::List(list)
-            }
-
             // Major type 5: a map of pairs of data items
             0xa0..=0xbb => {
                 let len = read_len(r, major - 0xa0)?;
                 Self::Map(read_map(r, len as usize)?)
-            }
-
-            // Major type 5: a map of pairs of data items (indefinite length)
-            0xbf => {
-                let pos = r.seek(SeekFrom::Current(0))?;
-                r.seek(SeekFrom::Start(pos))?;
-                Self::Map(read_map_il(r)?)
             }
 
             // Major type 6: optional semantic tagging of other major types
@@ -501,9 +455,9 @@ impl Decode<DagCbor> for Ipld {
             0xf4 => Self::Bool(false),
             0xf5 => Self::Bool(true),
             0xf6 => Self::Null,
-            0xf7 => Self::Null,
             0xfa => Self::Float(read_f32(r)? as f64),
             0xfb => Self::Float(read_f64(r)?),
+            0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
             _ => return Err(UnexpectedCode::new::<Self>(major).into()),
         };
         Ok(ipld)
@@ -568,16 +522,6 @@ impl References<DagCbor> for Ipld {
                 }
             }
 
-            // Major type 4: an array of data items (indefinite length)
-            0x9f => loop {
-                let major = read_u8(r)?;
-                if major == 0xff {
-                    break;
-                }
-                r.seek(SeekFrom::Current(-1))?;
-                <Self as References<DagCbor>>::references(c, r, set)?;
-            },
-
             // Major type 5: a map of pairs of data items
             0xa0..=0xbb => {
                 let len = read_len(r, major - 0xa0)?;
@@ -586,17 +530,6 @@ impl References<DagCbor> for Ipld {
                     <Self as References<DagCbor>>::references(c, r, set)?;
                 }
             }
-
-            // Major type 5: a map of pairs of data items (indefinite length)
-            0xbf => loop {
-                let major = read_u8(r)?;
-                if major == 0xff {
-                    break;
-                }
-                r.seek(SeekFrom::Current(-1))?;
-                <Self as References<DagCbor>>::references(c, r, set)?;
-                <Self as References<DagCbor>>::references(c, r, set)?;
-            },
 
             // Major type 6: optional semantic tagging of other major types
             0xd8 => {
@@ -622,6 +555,7 @@ impl References<DagCbor> for Ipld {
             0xfb => {
                 r.seek(SeekFrom::Current(8))?;
             }
+            0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
             major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
         };
         Ok(())
@@ -760,16 +694,6 @@ impl SkipOne for DagCbor {
                 }
             }
 
-            // Major type 4: an array of data items (indefinite length)
-            0x9f => loop {
-                let major = read_u8(r)?;
-                if major == 0xff {
-                    break;
-                }
-                r.seek(SeekFrom::Current(-1))?;
-                self.skip(r)?;
-            },
-
             // Major type 5: a map of pairs of data items
             0xa0..=0xbb => {
                 let len = read_len(r, major - 0xa0)?;
@@ -778,17 +702,6 @@ impl SkipOne for DagCbor {
                     self.skip(r)?;
                 }
             }
-
-            // Major type 5: a map of pairs of data items (indefinite length)
-            0xbf => loop {
-                let major = read_u8(r)?;
-                if major == 0xff {
-                    break;
-                }
-                r.seek(SeekFrom::Current(-1))?;
-                self.skip(r)?;
-                self.skip(r)?;
-            },
 
             // Major type 6: optional semantic tagging of other major types
             0xc0..=0xd7 => {
@@ -838,7 +751,6 @@ mod tests {
     use super::*;
     use crate::{error::UnexpectedEof, DagCborCodec};
     use libipld_core::codec::Codec;
-    use libipld_macro::ipld;
 
     #[test]
     fn il_map() {
@@ -852,12 +764,9 @@ mod tests {
             0x21, // Second value, -2
             0xFF, // "break"
         ];
-        let ipld = ipld!({
-            "Fun": true,
-            "Amt": -2,
-        });
-        let ipld2: Ipld = DagCborCodec.decode(&bytes).unwrap();
-        assert_eq!(ipld, ipld2);
+        DagCborCodec
+            .decode::<Ipld>(&bytes)
+            .expect_err("should have failed to decode indefinit length map");
     }
 
     #[test]

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -466,98 +466,107 @@ impl Decode<DagCbor> for Ipld {
 
 impl References<DagCbor> for Ipld {
     fn references<R: Read + Seek, E: Extend<Cid>>(
-        c: DagCbor,
+        _: DagCbor,
         r: &mut R,
         set: &mut E,
     ) -> Result<()> {
-        let major = read_u8(r)?;
-        match major {
-            // Major type 0: an unsigned integer
-            0x00..=0x17 => {}
-            0x18 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x19 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x1a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x1b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 1: a negative integer
-            0x20..=0x37 => {}
-            0x38 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0x39 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0x3a => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0x3b => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-
-            // Major type 2: a byte string
-            0x40..=0x5b => {
-                let len = read_len(r, major - 0x40)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 3: a text string
-            0x60..=0x7b => {
-                let len = read_len(r, major - 0x60)?;
-                r.seek(SeekFrom::Current(len as _))?;
-            }
-
-            // Major type 4: an array of data items
-            0x80..=0x9b => {
-                let len = read_len(r, major - 0x80)?;
-                for _ in 0..len {
-                    <Self as References<DagCbor>>::references(c, r, set)?;
+        let mut remaining: usize = 1;
+        while remaining > 0 {
+            let major = read_u8(r)?;
+            match major {
+                // Major type 0: an unsigned integer
+                0x00..=0x17 => {}
+                0x18 => {
+                    r.seek(SeekFrom::Current(1))?;
                 }
-            }
-
-            // Major type 5: a map of pairs of data items
-            0xa0..=0xbb => {
-                let len = read_len(r, major - 0xa0)?;
-                for _ in 0..len {
-                    <Self as References<DagCbor>>::references(c, r, set)?;
-                    <Self as References<DagCbor>>::references(c, r, set)?;
+                0x19 => {
+                    r.seek(SeekFrom::Current(2))?;
                 }
-            }
-
-            // Major type 6: optional semantic tagging of other major types
-            0xd8 => {
-                let tag = read_u8(r)?;
-                if tag == 42 {
-                    set.extend(std::iter::once(read_link(r)?));
-                } else {
-                    <Self as References<DagCbor>>::references(c, r, set)?;
+                0x1a => {
+                    r.seek(SeekFrom::Current(4))?;
                 }
-            }
+                0x1b => {
+                    r.seek(SeekFrom::Current(8))?;
+                }
 
-            // Major type 7: floating-point numbers and other simple data types that need no content
-            0xf4..=0xf7 => {}
-            0xf8 => {
-                r.seek(SeekFrom::Current(1))?;
-            }
-            0xf9 => {
-                r.seek(SeekFrom::Current(2))?;
-            }
-            0xfa => {
-                r.seek(SeekFrom::Current(4))?;
-            }
-            0xfb => {
-                r.seek(SeekFrom::Current(8))?;
-            }
-            0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
-            major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
-        };
+                // Major type 1: a negative integer
+                0x20..=0x37 => {}
+                0x38 => {
+                    r.seek(SeekFrom::Current(1))?;
+                }
+                0x39 => {
+                    r.seek(SeekFrom::Current(2))?;
+                }
+                0x3a => {
+                    r.seek(SeekFrom::Current(4))?;
+                }
+                0x3b => {
+                    r.seek(SeekFrom::Current(8))?;
+                }
+
+                // Major type 2: a byte string
+                0x40..=0x5b => {
+                    let len = read_len(r, major - 0x40)?;
+                    r.seek(SeekFrom::Current(len as _))?;
+                }
+
+                // Major type 3: a text string
+                0x60..=0x7b => {
+                    let len = read_len(r, major - 0x60)?;
+                    r.seek(SeekFrom::Current(len as _))?;
+                }
+
+                // Major type 4: an array of data items
+                0x80..=0x9b => {
+                    let len = read_len(r, major - 0x80)?;
+                    remaining = remaining
+                        .checked_add(len)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+
+                // Major type 5: a map of pairs of data items
+                0xa0..=0xbb => {
+                    let len = read_len(r, major - 0xa0)?;
+                    // TODO: consider using a checked "monad" type to simplify.
+                    let items = len
+                        .checked_mul(2)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                    remaining = remaining
+                        .checked_add(items)
+                        .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                }
+
+                // Major type 6: optional semantic tagging of other major types
+                0xd8 => {
+                    let tag = read_u8(r)?;
+                    if tag == 42 {
+                        set.extend(std::iter::once(read_link(r)?));
+                    } else {
+                        remaining = remaining
+                            .checked_add(1)
+                            .ok_or_else(LengthOutOfRange::new::<Self>)?;
+                    }
+                }
+
+                // Major type 7: floating-point numbers and other simple data types that need no content
+                0xf4..=0xf7 => {}
+                0xf8 => {
+                    r.seek(SeekFrom::Current(1))?;
+                }
+                0xf9 => {
+                    r.seek(SeekFrom::Current(2))?;
+                }
+                0xfa => {
+                    r.seek(SeekFrom::Current(4))?;
+                }
+                0xfb => {
+                    r.seek(SeekFrom::Current(8))?;
+                }
+                0x9f | 0xbf => return Err(IndefiniteLengthItem::new::<Self>().into()),
+                major => return Err(UnexpectedCode::new::<Ipld>(major).into()),
+            };
+            remaining -= 1;
+        }
         Ok(())
     }
 }

--- a/dag-cbor/src/encode.rs
+++ b/dag-cbor/src/encode.rs
@@ -13,7 +13,7 @@ use libipld_core::codec::Encode;
 use libipld_core::error::Result;
 use libipld_core::ipld::Ipld;
 
-use crate::cbor::*;
+use crate::cbor::{MajorKind, FALSE, TRUE};
 use crate::error::NumberOutOfRange;
 use crate::DagCborCodec as DagCbor;
 

--- a/dag-cbor/src/encode.rs
+++ b/dag-cbor/src/encode.rs
@@ -1,15 +1,19 @@
 //! CBOR encoder.
-use crate::error::NumberOutOfRange;
-use crate::DagCborCodec as DagCbor;
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::ops::Deref;
+use std::sync::Arc;
+
 use byteorder::{BigEndian, ByteOrder};
 use libipld_core::cid::Cid;
 use libipld_core::codec::Encode;
 use libipld_core::error::Result;
 use libipld_core::ipld::Ipld;
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::ops::Deref;
-use std::sync::Arc;
+
+use crate::cbor::*;
+use crate::error::NumberOutOfRange;
+use crate::DagCborCodec as DagCbor;
 
 /// Writes a null byte to a cbor encoded byte stream.
 pub fn write_null<W: Write>(w: &mut W) -> Result<()> {
@@ -18,7 +22,8 @@ pub fn write_null<W: Write>(w: &mut W) -> Result<()> {
 }
 
 /// Writes a u8 to a cbor encoded byte stream.
-pub fn write_u8<W: Write>(w: &mut W, major: u8, value: u8) -> Result<()> {
+pub fn write_u8<W: Write>(w: &mut W, major: MajorKind, value: u8) -> Result<()> {
+    let major = major as u8;
     if value <= 0x17 {
         let buf = [major << 5 | value];
         w.write_all(&buf)?;
@@ -30,11 +35,11 @@ pub fn write_u8<W: Write>(w: &mut W, major: u8, value: u8) -> Result<()> {
 }
 
 /// Writes a u16 to a cbor encoded byte stream.
-pub fn write_u16<W: Write>(w: &mut W, major: u8, value: u16) -> Result<()> {
+pub fn write_u16<W: Write>(w: &mut W, major: MajorKind, value: u16) -> Result<()> {
     if value <= u16::from(u8::max_value()) {
         write_u8(w, major, value as u8)?;
     } else {
-        let mut buf = [major << 5 | 25, 0, 0];
+        let mut buf = [(major as u8) << 5 | 25, 0, 0];
         BigEndian::write_u16(&mut buf[1..], value);
         w.write_all(&buf)?;
     }
@@ -42,11 +47,11 @@ pub fn write_u16<W: Write>(w: &mut W, major: u8, value: u16) -> Result<()> {
 }
 
 /// Writes a u32 to a cbor encoded byte stream.
-pub fn write_u32<W: Write>(w: &mut W, major: u8, value: u32) -> Result<()> {
+pub fn write_u32<W: Write>(w: &mut W, major: MajorKind, value: u32) -> Result<()> {
     if value <= u32::from(u16::max_value()) {
         write_u16(w, major, value as u16)?;
     } else {
-        let mut buf = [major << 5 | 26, 0, 0, 0, 0];
+        let mut buf = [(major as u8) << 5 | 26, 0, 0, 0, 0];
         BigEndian::write_u32(&mut buf[1..], value);
         w.write_all(&buf)?;
     }
@@ -54,11 +59,11 @@ pub fn write_u32<W: Write>(w: &mut W, major: u8, value: u32) -> Result<()> {
 }
 
 /// Writes a u64 to a cbor encoded byte stream.
-pub fn write_u64<W: Write>(w: &mut W, major: u8, value: u64) -> Result<()> {
+pub fn write_u64<W: Write>(w: &mut W, major: MajorKind, value: u64) -> Result<()> {
     if value <= u64::from(u32::max_value()) {
         write_u32(w, major, value as u32)?;
     } else {
-        let mut buf = [major << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
+        let mut buf = [(major as u8) << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
         BigEndian::write_u64(&mut buf[1..], value);
         w.write_all(&buf)?;
     }
@@ -67,12 +72,12 @@ pub fn write_u64<W: Write>(w: &mut W, major: u8, value: u64) -> Result<()> {
 
 /// Writes a tag to a cbor encoded byte stream.
 pub fn write_tag<W: Write>(w: &mut W, tag: u64) -> Result<()> {
-    write_u64(w, 6, tag)
+    write_u64(w, MajorKind::Tag, tag)
 }
 
 impl Encode<DagCbor> for bool {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        let buf = if *self { [0xf5] } else { [0xf4] };
+        let buf = if *self { [TRUE.into()] } else { [FALSE.into()] };
         w.write_all(&buf)?;
         Ok(())
     }
@@ -80,32 +85,32 @@ impl Encode<DagCbor> for bool {
 
 impl Encode<DagCbor> for u8 {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 0, *self)
+        write_u8(w, MajorKind::UnsignedInt, *self)
     }
 }
 
 impl Encode<DagCbor> for u16 {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u16(w, 0, *self)
+        write_u16(w, MajorKind::UnsignedInt, *self)
     }
 }
 
 impl Encode<DagCbor> for u32 {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u32(w, 0, *self)
+        write_u32(w, MajorKind::UnsignedInt, *self)
     }
 }
 
 impl Encode<DagCbor> for u64 {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u64(w, 0, *self)
+        write_u64(w, MajorKind::UnsignedInt, *self)
     }
 }
 
 impl Encode<DagCbor> for i8 {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
         if self.is_negative() {
-            write_u8(w, 1, -(*self + 1) as u8)
+            write_u8(w, MajorKind::NegativeInt, -(*self + 1) as u8)
         } else {
             (*self as u8).encode(c, w)
         }
@@ -115,7 +120,7 @@ impl Encode<DagCbor> for i8 {
 impl Encode<DagCbor> for i16 {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
         if self.is_negative() {
-            write_u16(w, 1, -(*self + 1) as u16)
+            write_u16(w, MajorKind::NegativeInt, -(*self + 1) as u16)
         } else {
             (*self as u16).encode(c, w)
         }
@@ -125,7 +130,7 @@ impl Encode<DagCbor> for i16 {
 impl Encode<DagCbor> for i32 {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
         if self.is_negative() {
-            write_u32(w, 1, -(*self + 1) as u32)
+            write_u32(w, MajorKind::NegativeInt, -(*self + 1) as u32)
         } else {
             (*self as u32).encode(c, w)
         }
@@ -135,7 +140,7 @@ impl Encode<DagCbor> for i32 {
 impl Encode<DagCbor> for i64 {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
         if self.is_negative() {
-            write_u64(w, 1, -(*self + 1) as u64)
+            write_u64(w, MajorKind::NegativeInt, -(*self + 1) as u64)
         } else {
             (*self as u64).encode(c, w)
         }
@@ -164,7 +169,7 @@ impl Encode<DagCbor> for f64 {
 
 impl Encode<DagCbor> for [u8] {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u64(w, 2, self.len() as u64)?;
+        write_u64(w, MajorKind::ByteString, self.len() as u64)?;
         w.write_all(self)?;
         Ok(())
     }
@@ -178,7 +183,7 @@ impl Encode<DagCbor> for Box<[u8]> {
 
 impl Encode<DagCbor> for str {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
-        write_u64(w, 3, self.len() as u64)?;
+        write_u64(w, MajorKind::TextString, self.len() as u64)?;
         w.write_all(self.as_bytes())?;
         Ok(())
     }
@@ -196,12 +201,12 @@ impl Encode<DagCbor> for i128 {
             if -(*self + 1) > u64::max_value() as i128 {
                 return Err(NumberOutOfRange::new::<i128>().into());
             }
-            write_u64(w, 1, -(*self + 1) as u64)?;
+            write_u64(w, MajorKind::NegativeInt, -(*self + 1) as u64)?;
         } else {
             if *self > u64::max_value() as i128 {
                 return Err(NumberOutOfRange::new::<i128>().into());
             }
-            write_u64(w, 0, *self as u64)?;
+            write_u64(w, MajorKind::UnsignedInt, *self as u64)?;
         }
         Ok(())
     }
@@ -214,7 +219,7 @@ impl Encode<DagCbor> for Cid {
         // TODO: don't allocate
         let buf = self.to_bytes();
         let len = buf.len();
-        write_u64(w, 2, len as u64 + 1)?;
+        write_u64(w, MajorKind::ByteString, len as u64 + 1)?;
         w.write_all(&[0])?;
         w.write_all(&buf[..len])?;
         Ok(())
@@ -234,7 +239,7 @@ impl<T: Encode<DagCbor>> Encode<DagCbor> for Option<T> {
 
 impl<T: Encode<DagCbor>> Encode<DagCbor> for Vec<T> {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u64(w, 4, self.len() as u64)?;
+        write_u64(w, MajorKind::Array, self.len() as u64)?;
         for value in self {
             value.encode(c, w)?;
         }
@@ -244,7 +249,7 @@ impl<T: Encode<DagCbor>> Encode<DagCbor> for Vec<T> {
 
 impl<K: Encode<DagCbor>, T: Encode<DagCbor> + 'static> Encode<DagCbor> for BTreeMap<K, T> {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u64(w, 5, self.len() as u64)?;
+        write_u64(w, MajorKind::Map, self.len() as u64)?;
         for (k, v) in self {
             k.encode(c, w)?;
             v.encode(c, w)?;
@@ -277,14 +282,14 @@ impl<T: Encode<DagCbor>> Encode<DagCbor> for Arc<T> {
 
 impl Encode<DagCbor> for () {
     fn encode<W: Write>(&self, _c: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 4, 0)?;
+        write_u8(w, MajorKind::Array, 0)?;
         Ok(())
     }
 }
 
 impl<A: Encode<DagCbor>> Encode<DagCbor> for (A,) {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 4, 1)?;
+        write_u8(w, MajorKind::Array, 1)?;
         self.0.encode(c, w)?;
         Ok(())
     }
@@ -292,7 +297,7 @@ impl<A: Encode<DagCbor>> Encode<DagCbor> for (A,) {
 
 impl<A: Encode<DagCbor>, B: Encode<DagCbor>> Encode<DagCbor> for (A, B) {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 4, 2)?;
+        write_u8(w, MajorKind::Array, 2)?;
         self.0.encode(c, w)?;
         self.1.encode(c, w)?;
         Ok(())
@@ -301,7 +306,7 @@ impl<A: Encode<DagCbor>, B: Encode<DagCbor>> Encode<DagCbor> for (A, B) {
 
 impl<A: Encode<DagCbor>, B: Encode<DagCbor>, C: Encode<DagCbor>> Encode<DagCbor> for (A, B, C) {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 4, 3)?;
+        write_u8(w, MajorKind::Array, 3)?;
         self.0.encode(c, w)?;
         self.1.encode(c, w)?;
         self.2.encode(c, w)?;
@@ -313,7 +318,7 @@ impl<A: Encode<DagCbor>, B: Encode<DagCbor>, C: Encode<DagCbor>, D: Encode<DagCb
     for (A, B, C, D)
 {
     fn encode<W: Write>(&self, c: DagCbor, w: &mut W) -> Result<()> {
-        write_u8(w, 4, 4)?;
+        write_u8(w, MajorKind::Array, 4)?;
         self.0.encode(c, w)?;
         self.1.encode(c, w)?;
         self.2.encode(c, w)?;

--- a/dag-cbor/src/error.rs
+++ b/dag-cbor/src/error.rs
@@ -19,6 +19,11 @@ impl NumberOutOfRange {
     }
 }
 
+/// Number is not minimally encoded.
+#[derive(Debug, Error)]
+#[error("Number not minimally encoded.")]
+pub struct NumberNotMinimal;
+
 /// Length larger than usize or too small, for example zero length cid field.
 #[derive(Debug, Error)]
 #[error("Length out of range when decoding {ty}.")]
@@ -99,7 +104,7 @@ impl MissingKey {
 /// Unknown cbor tag.
 #[derive(Debug, Error)]
 #[error("Unkown cbor tag `{0}`.")]
-pub struct UnknownTag(pub u8);
+pub struct UnknownTag(pub u64);
 
 /// Unexpected eof.
 #[derive(Debug, Error)]
@@ -110,20 +115,3 @@ pub struct UnexpectedEof;
 #[derive(Debug, Error)]
 #[error("Invalid Cid prefix: {0}")]
 pub struct InvalidCidPrefix(pub u8);
-
-/// DagCbor does not support indefinit length items (lists & maps).
-#[derive(Debug, Error)]
-#[error("Illegal cbor indefinite length item when decoding `{ty}`.")]
-pub struct IndefiniteLengthItem {
-    /// Type.
-    pub ty: &'static str,
-}
-
-impl IndefiniteLengthItem {
-    /// Creates a new `UnexpectedCode` error.
-    pub fn new<T>() -> Self {
-        Self {
-            ty: type_name::<T>(),
-        }
-    }
-}

--- a/dag-cbor/src/error.rs
+++ b/dag-cbor/src/error.rs
@@ -110,3 +110,20 @@ pub struct UnexpectedEof;
 #[derive(Debug, Error)]
 #[error("Invalid Cid prefix: {0}")]
 pub struct InvalidCidPrefix(pub u8);
+
+/// DagCbor does not support indefinit length items (lists & maps).
+#[derive(Debug, Error)]
+#[error("Illegal cbor indefinite length item when decoding `{ty}`.")]
+pub struct IndefiniteLengthItem {
+    /// Type.
+    pub ty: &'static str,
+}
+
+impl IndefiniteLengthItem {
+    /// Creates a new `UnexpectedCode` error.
+    pub fn new<T>() -> Self {
+        Self {
+            ty: type_name::<T>(),
+        }
+    }
+}

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -6,6 +6,7 @@ use core::convert::TryFrom;
 use libipld_core::codec::{Codec, Decode, Encode};
 pub use libipld_core::error::{Result, UnsupportedCodec};
 
+pub mod cbor;
 pub mod decode;
 pub mod encode;
 pub mod error;

--- a/dag-cbor/src/lib.rs
+++ b/dag-cbor/src/lib.rs
@@ -39,6 +39,7 @@ impl<T: Encode<DagCborCodec> + Decode<DagCborCodec>> DagCbor for T {}
 mod tests {
     use super::*;
     use libipld_core::cid::Cid;
+    use libipld_core::codec::assert_roundtrip;
     use libipld_core::ipld::Ipld;
     use libipld_core::multihash::{Code, MultihashDigest};
     use libipld_macro::ipld;
@@ -71,5 +72,29 @@ mod tests {
             .references::<Ipld, _>(&bytes, &mut set)
             .unwrap();
         assert!(set.contains(&cid));
+    }
+
+    #[test]
+    fn test_encode_max() {
+        assert_roundtrip(DagCborCodec, &i8::MAX, &Ipld::Integer(i8::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i16::MAX, &Ipld::Integer(i16::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i32::MAX, &Ipld::Integer(i32::MAX as i128));
+        assert_roundtrip(DagCborCodec, &i64::MAX, &Ipld::Integer(i64::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u8::MAX, &Ipld::Integer(u8::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u16::MAX, &Ipld::Integer(u16::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u32::MAX, &Ipld::Integer(u32::MAX as i128));
+        assert_roundtrip(DagCborCodec, &u64::MAX, &Ipld::Integer(u64::MAX as i128));
+    }
+
+    #[test]
+    fn test_encode_min() {
+        assert_roundtrip(DagCborCodec, &i8::MIN, &Ipld::Integer(i8::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i16::MIN, &Ipld::Integer(i16::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i32::MIN, &Ipld::Integer(i32::MIN as i128));
+        assert_roundtrip(DagCborCodec, &i64::MIN, &Ipld::Integer(i64::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u8::MIN, &Ipld::Integer(u8::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u16::MIN, &Ipld::Integer(u16::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u32::MIN, &Ipld::Integer(u32::MIN as i128));
+        assert_roundtrip(DagCborCodec, &u64::MIN, &Ipld::Integer(u64::MIN as i128));
     }
 }

--- a/dag-cbor/tests/roundtrip.rs
+++ b/dag-cbor/tests/roundtrip.rs
@@ -1,12 +1,10 @@
 use libipld_cbor::DagCborCodec;
 use libipld_core::{
-    cid::Cid,
-    codec::References,
     codec::{assert_roundtrip, Codec, Decode},
     ipld::Ipld,
     raw_value::{IgnoredAny, RawValue, SkipOne},
 };
-use std::{io::Cursor, result, str::FromStr};
+use std::{io::Cursor, result};
 
 #[test]
 fn roundtrip_with_cid() {
@@ -91,30 +89,6 @@ fn raw_value() {
     assert_eq!(raw.as_ref(), &hex::decode("a163666f6fd82a5800").unwrap());
     let r: result::Result<RawValue<DagCborCodec>, _> = Decode::decode(DagCborCodec, &mut r);
     assert!(r.is_err());
-}
-
-#[test]
-fn indefinite_length_skip() {
-    let data = hex::decode("9fa163666f6fd82a58250001711220f3bffba2b0bbc80a1c4ba39c789bb8e1eef08dc2792e4beb0fbaff1369b7a035ff").unwrap();
-    let mut r = Cursor::new(&data);
-    assert!(IgnoredAny::decode(DagCborCodec, &mut r).is_ok());
-    assert_eq!(r.position(), 48);
-}
-
-#[test]
-fn indefinite_length_refs() {
-    let data = hex::decode("9fa163666f6fd82a58250001711220f3bffba2b0bbc80a1c4ba39c789bb8e1eef08dc2792e4beb0fbaff1369b7a035ff").unwrap();
-    let mut refs = Vec::new();
-    let mut r = Cursor::new(&data);
-    assert!(
-        <Ipld as References<DagCborCodec>>::references(DagCborCodec, &mut r, &mut refs).is_ok()
-    );
-    assert_eq!(
-        refs[0],
-        Cid::from_str("bafyreihtx752fmf3zafbys5dtr4jxohb53yi3qtzfzf6wd5274jwtn5agu").unwrap()
-    );
-    assert_eq!(refs.len(), 1);
-    assert_eq!(r.position(), 48);
 }
 
 #[test]

--- a/dag-cbor/tests/roundtrip.rs
+++ b/dag-cbor/tests/roundtrip.rs
@@ -1,6 +1,6 @@
 use libipld_cbor::DagCborCodec;
 use libipld_core::{
-    codec::{assert_roundtrip, Codec, Decode},
+    codec::{assert_roundtrip, Codec, Decode, Encode},
     ipld::Ipld,
     raw_value::{IgnoredAny, RawValue, SkipOne},
 };
@@ -45,17 +45,31 @@ fn zero_length_cid() {
     let _: Ipld = DagCborCodec.decode(&input).unwrap();
 }
 
+// 3x some cbor and then some garbage
+fn cbor_seq() -> Vec<u8> {
+    let mut buf = Vec::new();
+    1u8.encode(DagCborCodec, &mut buf).unwrap();
+    (u16::MAX as u64 + 1)
+        .encode(DagCborCodec, &mut buf)
+        .unwrap();
+    vec![String::from("foo")]
+        .encode(DagCborCodec, &mut buf)
+        .unwrap();
+    buf.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+    buf
+}
+
 // test SkipOne trait for cbor
 #[test]
 fn skip() {
-    // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     DagCborCodec.skip(&mut r).unwrap();
-    assert_eq!(r.position(), 9);
+    assert_eq!(r.position(), 1);
     DagCborCodec.skip(&mut r).unwrap();
-    assert_eq!(r.position(), 18);
+    assert_eq!(r.position(), 6);
+    DagCborCodec.skip(&mut r).unwrap();
+    assert_eq!(r.position(), 11);
     assert!(DagCborCodec.skip(&mut r).is_err());
 }
 
@@ -63,13 +77,14 @@ fn skip() {
 #[test]
 fn ignored_any() {
     // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 9);
+    assert_eq!(r.position(), 1);
     let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 18);
+    assert_eq!(r.position(), 6);
+    let _x: IgnoredAny = Decode::decode(DagCborCodec, &mut r).unwrap();
+    assert_eq!(r.position(), 11);
     let r: result::Result<IgnoredAny, _> = Decode::decode(DagCborCodec, &mut r);
     assert!(r.is_err());
 }
@@ -78,15 +93,17 @@ fn ignored_any() {
 #[test]
 fn raw_value() {
     // 3x some cbor and then some garbage
-    let input = "a163666f6fd82a5800a163666f6fd82a5800ffffff";
-    let input = hex::decode(input).unwrap();
+    let input = cbor_seq();
     let mut r = Cursor::new(&input);
     let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 9);
-    assert_eq!(raw.as_ref(), &hex::decode("a163666f6fd82a5800").unwrap());
+    assert_eq!(r.position(), 1);
+    assert_eq!(raw.as_ref(), &input[0..1]);
     let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
-    assert_eq!(r.position(), 18);
-    assert_eq!(raw.as_ref(), &hex::decode("a163666f6fd82a5800").unwrap());
+    assert_eq!(r.position(), 6);
+    assert_eq!(raw.as_ref(), &input[1..6]);
+    let raw: RawValue<DagCborCodec> = Decode::decode(DagCborCodec, &mut r).unwrap();
+    assert_eq!(r.position(), 11);
+    assert_eq!(raw.as_ref(), &input[6..11]);
     let r: result::Result<RawValue<DagCborCodec>, _> = Decode::decode(DagCborCodec, &mut r);
     assert!(r.is_err());
 }

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -8,7 +8,6 @@ description = "ipld json codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
 [dependencies]
-base64 = "0.13.0"
 libipld-core = { version = "0.12.0", path = "../core" }
 multihash = "0.14.0"
 serde_json = { version = "1.0.64", features = ["float_roundtrip"] }

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/ipfs-rust/rust-ipld"
 base64 = "0.13.0"
 libipld-core = { version = "0.12.0", path = "../core" }
 multihash = "0.14.0"
-serde_json = "1.0.64"
+serde_json = { version = "1.0.64", features = ["float_roundtrip"] }
 serde = { version = "1.0.126", features = ["derive"] }

--- a/dag-json/src/codec.rs
+++ b/dag-json/src/codec.rs
@@ -1,7 +1,7 @@
 use core::convert::TryFrom;
 use libipld_core::cid::Cid;
 use libipld_core::ipld::Ipld;
-use libipld_core::multibase::{self, Base};
+use libipld_core::multibase::Base;
 use serde::de::Error as SerdeError;
 use serde::{de, ser, Deserialize, Serialize};
 use serde_json::ser::Serializer;
@@ -32,11 +32,8 @@ fn serialize<S: ser::Serializer>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
         Ipld::Float(f64) => ser.serialize_f64(*f64),
         Ipld::String(string) => ser.serialize_str(string),
         Ipld::Bytes(bytes) => {
-            let base_encoded = multibase::encode(Base::Base64, bytes);
-            let byteskv = BTreeMap::from([
-                // We need it to be base64 encoded, without the Multibase prefix.
-                ("bytes", &base_encoded[1..]),
-            ]);
+            let base_encoded = Base::Base64.encode(bytes);
+            let byteskv = BTreeMap::from([("bytes", &base_encoded)]);
             let slashkv = BTreeMap::from([("/", byteskv)]);
             ser.collect_map(slashkv)
         }

--- a/dag-json/src/codec.rs
+++ b/dag-json/src/codec.rs
@@ -192,17 +192,10 @@ impl<'de> de::Visitor<'de> for JsonVisitor {
             if key == RESERVED_KEY && values.len() == 1 {
                 if let Some((bytes_key, Ipld::String(bytes_value))) = map.iter().next() {
                     if bytes_key == BYTES_KEY && values.len() == 1 {
-                        let multibase_prefixed = Base::Base64.code().to_string() + bytes_value;
-                        if let Ok((decoded_base, decoded_bytes)) =
-                            multibase::decode(multibase_prefixed)
-                        {
-                            if decoded_base != Base::Base64 {
-                                return Err(SerdeError::custom(
-                                    "bytes kind must be base-64 encoded",
-                                ));
-                            }
-                            return Ok(Ipld::Bytes(decoded_bytes));
-                        }
+                        let decoded_bytes = Base::Base64.decode(bytes_value).map_err(|_| {
+                            SerdeError::custom("bytes kind must be base-64 encoded")
+                        })?;
+                        return Ok(Ipld::Bytes(decoded_bytes));
                     }
                 }
             }

--- a/dag-json/src/codec.rs
+++ b/dag-json/src/codec.rs
@@ -1,6 +1,7 @@
 use core::convert::TryFrom;
 use libipld_core::cid::Cid;
 use libipld_core::ipld::Ipld;
+use libipld_core::multibase::{self, Base};
 use serde::de::Error as SerdeError;
 use serde::{de, ser, Deserialize, Serialize};
 use serde_json::ser::Serializer;
@@ -9,7 +10,8 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{Read, Write};
 
-const LINK_KEY: &str = "/";
+const RESERVED_KEY: &str = "/";
+const BYTES_KEY: &str = "bytes";
 
 pub fn encode<W: Write>(ipld: &Ipld, writer: &mut W) -> Result<(), Error> {
     let mut ser = Serializer::new(writer);
@@ -29,7 +31,15 @@ fn serialize<S: ser::Serializer>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
         Ipld::Integer(i128) => ser.serialize_i128(*i128),
         Ipld::Float(f64) => ser.serialize_f64(*f64),
         Ipld::String(string) => ser.serialize_str(string),
-        Ipld::Bytes(bytes) => ser.serialize_bytes(bytes),
+        Ipld::Bytes(bytes) => {
+            let base_encoded = multibase::encode(Base::Base64, bytes);
+            let byteskv = BTreeMap::from([
+                // We need it to be base64 encoded, without the Multibase prefix.
+                ("bytes", &base_encoded[1..]),
+            ]);
+            let slashkv = BTreeMap::from([("/", byteskv)]);
+            ser.collect_map(slashkv)
+        }
         Ipld::List(list) => {
             let wrapped = list.iter().map(Wrapper);
             ser.collect_seq(wrapped)
@@ -39,9 +49,8 @@ fn serialize<S: ser::Serializer>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
             ser.collect_map(wrapped)
         }
         Ipld::Link(link) => {
-            let value = base64::encode(&link.to_bytes());
             let mut map = BTreeMap::new();
-            map.insert("/", value);
+            map.insert("/", link.to_string());
 
             ser.collect_map(map)
         }
@@ -168,13 +177,34 @@ impl<'de> de::Visitor<'de> for JsonVisitor {
             values.push((key, value));
         }
 
-        // JSON Object represents IPLD Link if it is `{ "/": "...." }` therefor
-        // we valiadet if that is the case here.
+        // JSON Object represents an IPLD Link if it is a slash, followed by a string
+        // (`{ "/": "...." }`) therefore we validate if that is the case here.
         if let Some((key, WrapperOwned(Ipld::String(value)))) = values.first() {
-            if key == LINK_KEY && values.len() == 1 {
-                let link = base64::decode(value).map_err(SerdeError::custom)?;
-                let cid = Cid::try_from(link).map_err(SerdeError::custom)?;
+            if key == RESERVED_KEY && values.len() == 1 {
+                let cid = Cid::try_from(value.clone()).map_err(SerdeError::custom)?;
                 return Ok(Ipld::Link(cid));
+            }
+        }
+        // JSON Object represents IPLD bytes if it is a slash, followed by an object which contains
+        // only a single key called "bytes", where the value is a string.
+        if let Some((key, WrapperOwned(Ipld::Map(map)))) = values.first() {
+            // Object with a slash
+            if key == RESERVED_KEY && values.len() == 1 {
+                if let Some((bytes_key, Ipld::String(bytes_value))) = map.iter().next() {
+                    if bytes_key == BYTES_KEY && values.len() == 1 {
+                        let multibase_prefixed = Base::Base64.code().to_string() + bytes_value;
+                        if let Ok((decoded_base, decoded_bytes)) =
+                            multibase::decode(multibase_prefixed)
+                        {
+                            if decoded_base != Base::Base64 {
+                                return Err(SerdeError::custom(
+                                    "bytes kind must be base-64 encoded",
+                                ));
+                            }
+                            return Ok(Ipld::Bytes(decoded_bytes));
+                        }
+                    }
+                }
             }
         }
 

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -84,10 +84,7 @@ mod tests {
 
         assert_eq!(
             std::str::from_utf8(&contact_encoded).unwrap(),
-            format!(
-                r#"{{"details":{{"/":"{}"}},"name":"Hello World!"}}"#,
-                base64::encode(cid.to_bytes()),
-            )
+            format!(r#"{{"details":{{"/":"{}"}},"name":"Hello World!"}}"#, cid)
         );
 
         let contact_decoded: Ipld = DagJsonCodec.decode(&contact_encoded).unwrap();


### PR DESCRIPTION
This PR add spec compliant DAG-CBOR/DAG-JSON encoding/decoding. It was locally tested against https://github.com/ipld/codec-fixtures (I'll push that code, once we have a release).

This branch is based on the of the [`next` branch](https://github.com/ipld/libipld/tree/next). The only missing thing were:

 - DAG-CBOR: map key sort order
 - DAG-JSON: supporting the binary kind
 
Here's a link to the diff between `next` branch and this PR: https://github.com/ipld/libipld/compare/next..dag-json-cbor-encoding
