### PR TITLE
feat: make libipld-core no_std compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,24 @@ jobs:
 
     - name: cargo clippy
       run: cargo clippy --workspace --all-features --examples --tests -- -D warnings
+
+  build-no-std:
+    name: Build no_std (libipld-core)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: thumbv6m-none-eabi
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --target thumbv6m-none-eabi --manifest-path core/Cargo.toml

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,12 +7,18 @@ license = "MIT OR Apache-2.0"
 description = "Base traits and definitions used by ipld codecs."
 repository = "https://github.com/ipfs-rust/rust-ipld"
 
+[features]
+default = ["std"]
+std = ["anyhow/std", "cid/std", "multibase/std", "multihash/std", "thiserror"]
+
 [dependencies]
-anyhow = "1.0.40"
-cid = { version = "0.8.0", default-features = false, features = ["std"] }
-multibase = "0.9.1"
-multihash = { version = "0.16.0", default-features = false, features = ["std"] }
-thiserror = "1.0.25"
+anyhow = { version = "1.0.40", default-features = false }
+cid = { version = "0.8.0", default-features = false, features = ["alloc"] }
+core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+multihash = { version = "0.16.0", default-features = false, features = ["alloc"] }
+
+multibase = { version = "0.9.1", default-features = false, optional = true }
+thiserror = {version = "1.0.25", optional = true }
 
 [dev-dependencies]
-multihash = "0.16.0"
+multihash = { version = "0.16.0", default-features = false, features = ["multihash-impl", "blake3"] }

--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -1,13 +1,10 @@
 //! `Ipld` codecs.
 use alloc::{format, string::String, vec::Vec};
 use core::{convert::TryFrom, ops::Deref};
-#[cfg(not(feature = "std"))]
-use core2::io::{Cursor, Read, Seek, Write};
-#[cfg(feature = "std")]
-use std::io::{Cursor, Read, Seek, Write};
 
 use crate::cid::Cid;
 use crate::error::{Result, UnsupportedCodec};
+use crate::io::{Cursor, Read, Seek, Write};
 use crate::ipld::Ipld;
 
 /// Codec trait.

--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -1,10 +1,14 @@
 //! `Ipld` codecs.
+use alloc::{format, string::String, vec::Vec};
+use core::{convert::TryFrom, ops::Deref};
+#[cfg(not(feature = "std"))]
+use core2::io::{Cursor, Read, Seek, Write};
+#[cfg(feature = "std")]
+use std::io::{Cursor, Read, Seek, Write};
+
 use crate::cid::Cid;
 use crate::error::{Result, UnsupportedCodec};
 use crate::ipld::Ipld;
-use core::convert::TryFrom;
-use std::io::{Cursor, Read, Seek, Write};
-use std::ops::Deref;
 
 /// Codec trait.
 pub trait Codec:
@@ -80,7 +84,7 @@ pub trait References<C: Codec>: Sized {
 pub fn assert_roundtrip<C, T>(c: C, data: &T, ipld: &Ipld)
 where
     C: Codec,
-    T: Decode<C> + Encode<C> + std::fmt::Debug + PartialEq,
+    T: Decode<C> + Encode<C> + core::fmt::Debug + PartialEq,
     Ipld: Decode<C> + Encode<C>,
 {
     fn hex(bytes: &[u8]) -> String {
@@ -109,11 +113,7 @@ where
 mod tests {
     use super::*;
     use crate::ipld::Ipld;
-    use thiserror::Error;
-
-    #[derive(Debug, Error)]
-    #[error("not null")]
-    pub struct NotNull;
+    use anyhow::anyhow;
 
     #[derive(Clone, Copy, Debug)]
     struct CodecImpl;
@@ -137,8 +137,8 @@ mod tests {
     impl Encode<CodecImpl> for Ipld {
         fn encode<W: Write>(&self, _: CodecImpl, w: &mut W) -> Result<()> {
             match self {
-                Self::Null => Ok(w.write_all(&[0])?),
-                _ => Err(NotNull.into()),
+                Self::Null => Ok(w.write_all(&[0]).map_err(anyhow::Error::msg)?),
+                _ => Err(anyhow!("not null")),
             }
         }
     }
@@ -146,11 +146,11 @@ mod tests {
     impl Decode<CodecImpl> for Ipld {
         fn decode<R: Read>(_: CodecImpl, r: &mut R) -> Result<Self> {
             let mut buf = [0; 1];
-            r.read_exact(&mut buf)?;
+            r.read_exact(&mut buf).map_err(anyhow::Error::msg)?;
             if buf[0] == 0 {
                 Ok(Ipld::Null)
             } else {
-                Err(NotNull.into())
+                Err(anyhow!("not null"))
             }
         }
     }

--- a/core/src/convert.rs
+++ b/core/src/convert.rs
@@ -1,7 +1,13 @@
 //! Conversion to and from ipld.
 use crate::cid::Cid;
 use crate::ipld::Ipld;
-use std::collections::BTreeMap;
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 macro_rules! derive_to_ipld_prim {
     ($enum:ident, $ty:ty, $fn:ident) => {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,37 +1,48 @@
 //! `Ipld` error definitions.
+use alloc::{string::String, vec::Vec};
+
 use crate::cid::Cid;
 use crate::ipld::{Ipld, IpldIndex};
 pub use anyhow::{Error, Result};
+#[cfg(feature = "std")]
 use thiserror::Error;
 
 /// Block exceeds 1MiB.
-#[derive(Clone, Copy, Debug, Error)]
-#[error("Block size {0} exceeds 1MiB.")]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Error), error("Block size {0} exceeds 1MiB."))]
 pub struct BlockTooLarge(pub usize);
 
 /// The codec is unsupported.
-#[derive(Clone, Copy, Debug, Error)]
-#[error("Unsupported codec {0:?}.")]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Error), error("Unsupported codec {0:?}."))]
 pub struct UnsupportedCodec(pub u64);
 
 /// The multihash is unsupported.
-#[derive(Clone, Copy, Debug, Error)]
-#[error("Unsupported multihash {0:?}.")]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Error), error("Unsupported multihash {0:?}."))]
 pub struct UnsupportedMultihash(pub u64);
 
 /// Hash does not match the CID.
-#[derive(Clone, Debug, Error)]
-#[error("Hash of data does not match the CID.")]
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "std",
+    derive(Error),
+    error("Hash of data does not match the CID.")
+)]
 pub struct InvalidMultihash(pub Vec<u8>);
 
 /// The block wasn't found. The supplied string is a CID.
-#[derive(Clone, Copy, Debug, Error)]
-#[error("Failed to retrieve block {0}.")]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Error), error("Failed to retrieve block {0}."))]
 pub struct BlockNotFound(pub Cid);
 
 /// Type error.
-#[derive(Clone, Debug, Error)]
-#[error("Expected {expected:?} but found {found:?}")]
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "std",
+    derive(Error),
+    error("Expected {expected:?} but found {found:?}")
+)]
 pub struct TypeError {
     /// The expected type.
     pub expected: TypeErrorType,
@@ -46,6 +57,13 @@ impl TypeError {
             expected: expected.into(),
             found: found.into(),
         }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl core::fmt::Display for TypeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "Expected {:?} but found {:?}", self.expected, self.found)
     }
 }
 

--- a/core/src/ipld.rs
+++ b/core/src/ipld.rs
@@ -1,7 +1,16 @@
 //! Ipld representation.
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use core::fmt;
+
 use crate::cid::Cid;
 use crate::error::TypeError;
-use std::collections::BTreeMap;
 
 /// Ipld
 #[derive(Clone, PartialEq)]
@@ -26,8 +35,8 @@ pub enum Ipld {
     Link(Cid),
 }
 
-impl std::fmt::Debug for Ipld {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Ipld {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             match self {
                 Self::Null => write!(f, "Null"),
@@ -144,7 +153,7 @@ impl Ipld {
     pub fn references<E: Extend<Cid>>(&self, set: &mut E) {
         for ipld in self.iter() {
             if let Ipld::Link(cid) = ipld {
-                set.extend(std::iter::once(cid.to_owned()));
+                set.extend(core::iter::once(cid.to_owned()));
             }
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,3 +17,8 @@ pub use cid;
 #[cfg(feature = "std")]
 pub use multibase;
 pub use multihash;
+
+#[cfg(not(feature = "std"))]
+use core2::io;
+#[cfg(feature = "std")]
+use std::io;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,9 @@
 //! Core ipld types used by ipld codecs.
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod codec;
 pub mod convert;
@@ -11,5 +14,6 @@ pub mod raw;
 pub mod raw_value;
 
 pub use cid;
+#[cfg(feature = "std")]
 pub use multibase;
 pub use multihash;

--- a/core/src/link.rs
+++ b/core/src/link.rs
@@ -6,14 +6,11 @@ use core::{
     marker::PhantomData,
     ops::Deref,
 };
-#[cfg(not(feature = "std"))]
-use core2::io::{Read, Seek, Write};
-#[cfg(feature = "std")]
-use std::io::{Read, Seek, Write};
 
 use crate::cid::Cid;
 use crate::codec::{Codec, Decode, Encode};
 use crate::error::Result;
+use crate::io::{Read, Seek, Write};
 
 /// Typed cid.
 #[derive(Debug)]

--- a/core/src/link.rs
+++ b/core/src/link.rs
@@ -1,12 +1,19 @@
 //! Typed cid.
+use core::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::Deref,
+};
+#[cfg(not(feature = "std"))]
+use core2::io::{Read, Seek, Write};
+#[cfg(feature = "std")]
+use std::io::{Read, Seek, Write};
+
 use crate::cid::Cid;
 use crate::codec::{Codec, Decode, Encode};
 use crate::error::Result;
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
-use std::io::{Read, Seek, Write};
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 /// Typed cid.
 #[derive(Debug)]
@@ -30,8 +37,8 @@ impl<T> Link<T> {
     }
 }
 
-impl<T> std::fmt::Display for Link<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<T> fmt::Display for Link<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.cid.fmt(f)
     }
 }

--- a/core/src/raw.rs
+++ b/core/src/raw.rs
@@ -1,14 +1,11 @@
 //! Implements the raw codec.
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{convert::TryFrom, iter::Extend};
-#[cfg(not(feature = "std"))]
-use core2::io::{Read, Seek, Write};
-#[cfg(feature = "std")]
-use std::io::{Read, Seek, Write};
 
 use crate::cid::Cid;
 use crate::codec::{Codec, Decode, Encode, References};
 use crate::error::{Result, UnsupportedCodec};
+use crate::io::{Read, Seek, Write};
 use crate::ipld::Ipld;
 
 /// Raw codec.

--- a/core/src/raw_value.rs
+++ b/core/src/raw_value.rs
@@ -1,12 +1,9 @@
 //! misc stuff
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{convert::TryFrom, marker::PhantomData};
-#[cfg(not(feature = "std"))]
-use core2::io::{Read, Seek, SeekFrom, Write};
-#[cfg(feature = "std")]
-use std::io::{Read, Seek, SeekFrom, Write};
 
 use crate::codec::{Codec, Decode, Encode};
+use crate::io::{Read, Seek, SeekFrom, Write};
 
 /// A raw value for a certain codec.
 ///


### PR DESCRIPTION
Introduce `std` features, so that it can be used in no_std environments.

Closes #116.