### PR TITLE
chore: add cargo-release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT OR Apache-2.0"
 description = "library for dealing with ipld"
 repository = "https://github.com/ipld/libipld"
 
+[package.metadata.release]
+consolidate-commits = true
+consolidate-pushes = true
+shared-version = true
+
 [dependencies]
 async-trait = "0.1.50"
 cached = { version = "0.30.0", default-features = false }

--- a/dag-cbor-derive/examples/renamed-package/Cargo.toml
+++ b/dag-cbor-derive/examples/renamed-package/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 
+[package.metadata.release]
+release = false
+
 [dependencies]
 ipld = { path = "../../../", package = "libipld"}


### PR DESCRIPTION
In order to make releasing easier, add metadata for cargo-release. With this
information you can e.g. run `cargo release --workspace minor` and
it will do the expected thing.

Currently we rely on all crates being bumped to the same version. This is due
to the `shared-version` setting, that makes sure that the commit message has
the `{{version}}` correctly expanded.