### PR TITLE
feat: implement Serde (de)serializer for `Ipld` enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,24 @@ jobs:
         with:
           command: build
           args: --no-default-features --target thumbv6m-none-eabi --manifest-path core/Cargo.toml
+
+  build-no-std-serde:
+    name: Build no_std (libipld-core), but with the `serde-codec` feature enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          # `thumbv6m-none-eabi` can't be used as Serde doesn't compile there.
+          args: --no-default-features --features serde-codec --manifest-path core/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ dag-cbor = ["libipld-cbor"]
 dag-json = ["libipld-json"]
 dag-pb = ["libipld-pb"]
 derive = ["libipld-cbor-derive"]
+serde-codec = ["libipld-core/serde-codec"]
 
 [workspace]
 members = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ipfs-rust/rust-ipld"
 [features]
 default = ["std"]
 std = ["anyhow/std", "cid/std", "multibase/std", "multihash/std", "thiserror"]
+serde-codec = ["cid/serde-codec", "serde"]
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
@@ -18,7 +19,10 @@ core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 multihash = { version = "0.16.0", default-features = false, features = ["alloc"] }
 
 multibase = { version = "0.9.1", default-features = false, optional = true }
+serde = { version = "1.0.132", default-features= false, features = ["alloc"], optional = true }
 thiserror = {version = "1.0.25", optional = true }
 
 [dev-dependencies]
 multihash = { version = "0.16.0", default-features = false, features = ["multihash-impl", "blake3"] }
+serde_test = "1.0.132"
+serde_bytes = "0.11.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 multihash = { version = "0.16.0", default-features = false, features = ["alloc"] }
 
 multibase = { version = "0.9.1", default-features = false, optional = true }
-serde = { version = "1.0.132", default-features= false, features = ["alloc"], optional = true }
+serde = { version = "1.0.132", default-features = false, features = ["alloc"], optional = true }
 thiserror = {version = "1.0.25", optional = true }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ serde-codec = ["cid/serde-codec", "serde"]
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
-cid = { version = "0.8.0", default-features = false, features = ["alloc"] }
+cid = { version = "0.8.3", default-features = false, features = ["alloc"] }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 multihash = { version = "0.16.0", default-features = false, features = ["alloc"] }
 
@@ -26,3 +26,4 @@ thiserror = {version = "1.0.25", optional = true }
 multihash = { version = "0.16.0", default-features = false, features = ["multihash-impl", "blake3"] }
 serde_test = "1.0.132"
 serde_bytes = "0.11.5"
+serde_json = "1.0.79"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -36,6 +36,26 @@ pub struct InvalidMultihash(pub Vec<u8>);
 #[cfg_attr(feature = "std", derive(Error), error("Failed to retrieve block {0}."))]
 pub struct BlockNotFound(pub Cid);
 
+/// Error during Serde operations.
+#[cfg(feature = "serde-codec")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "std", derive(Error), error("Serde error: {0}."))]
+pub struct SerdeError(String);
+
+#[cfg(feature = "serde-codec")]
+impl serde::de::Error for SerdeError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}
+
+#[cfg(feature = "serde-codec")]
+impl serde::ser::Error for SerdeError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        Self(msg.to_string())
+    }
+}
+
 /// Type error.
 #[derive(Clone, Debug)]
 #[cfg_attr(

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,6 @@
 //! `Ipld` error definitions.
+#[cfg(feature = "serde-codec")]
+use alloc::string::ToString;
 use alloc::{string::String, vec::Vec};
 
 use crate::cid::Cid;
@@ -39,8 +41,14 @@ pub struct BlockNotFound(pub Cid);
 /// Error during Serde operations.
 #[cfg(feature = "serde-codec")]
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "std", derive(Error), error("Serde error: {0}."))]
 pub struct SerdeError(String);
+
+#[cfg(feature = "serde-codec")]
+impl core::fmt::Display for SerdeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Serde error: {}", self.0)
+    }
+}
 
 #[cfg(feature = "serde-codec")]
 impl serde::de::Error for SerdeError {
@@ -55,6 +63,9 @@ impl serde::ser::Error for SerdeError {
         Self(msg.to_string())
     }
 }
+
+#[cfg(feature = "serde-codec")]
+impl serde::ser::StdError for SerdeError {}
 
 /// Type error.
 #[derive(Clone, Debug)]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -44,14 +44,14 @@ pub struct SerdeError(String);
 
 #[cfg(feature = "serde-codec")]
 impl serde::de::Error for SerdeError {
-    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+    fn custom<T: core::fmt::Display>(msg: T) -> Self {
         Self(msg.to_string())
     }
 }
 
 #[cfg(feature = "serde-codec")]
 impl serde::ser::Error for SerdeError {
-    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+    fn custom<T: core::fmt::Display>(msg: T) -> Self {
         Self(msg.to_string())
     }
 }

--- a/core/src/ipld.rs
+++ b/core/src/ipld.rs
@@ -7,13 +7,13 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use core::fmt;
+use core::{cmp::Ordering, fmt};
 
 use crate::cid::Cid;
 use crate::error::TypeError;
 
 /// Ipld
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, PartialOrd)]
 pub enum Ipld {
     /// Represents the absence of a value or the value undefined.
     Null,
@@ -33,6 +33,21 @@ pub enum Ipld {
     Map(BTreeMap<String, Ipld>),
     /// Represents a map of integers.
     Link(Cid),
+}
+
+// Eq cannot be derived due to the [`Ipld::Float`]. The IPLD Data Model forbids non numeric float
+// values, hence it's OK to implement `Eq`.
+impl Eq for Ipld {}
+
+// TODO vmx 2021-12-21: Make sure that special float values like Nan or Infinity are never
+// constructed and error in case we do.
+/// The sort order is arbitrary.
+#[allow(clippy::derive_ord_xor_partial_ord)]
+impl Ord for Ipld {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other)
+            .expect("NaN and Infinity are not supported by IPLD.")
+    }
 }
 
 impl fmt::Debug for Ipld {

--- a/core/src/ipld.rs
+++ b/core/src/ipld.rs
@@ -7,13 +7,13 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use core::{cmp::Ordering, fmt};
+use core::fmt;
 
 use crate::cid::Cid;
 use crate::error::TypeError;
 
 /// Ipld
-#[derive(Clone, PartialEq, PartialOrd)]
+#[derive(Clone, PartialEq)]
 pub enum Ipld {
     /// Represents the absence of a value or the value undefined.
     Null,
@@ -33,21 +33,6 @@ pub enum Ipld {
     Map(BTreeMap<String, Ipld>),
     /// Represents a map of integers.
     Link(Cid),
-}
-
-// Eq cannot be derived due to the [`Ipld::Float`]. The IPLD Data Model forbids non numeric float
-// values, hence it's OK to implement `Eq`.
-impl Eq for Ipld {}
-
-// TODO vmx 2021-12-21: Make sure that special float values like Nan or Infinity are never
-// constructed and error in case we do.
-/// The sort order is arbitrary.
-#[allow(clippy::derive_ord_xor_partial_ord)]
-impl Ord for Ipld {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other)
-            .expect("NaN and Infinity are not supported by IPLD.")
-    }
 }
 
 impl fmt::Debug for Ipld {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core ipld types used by ipld codecs.
 #![deny(missing_docs)]
-#![deny(warnings)]
+//#![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
@@ -12,6 +12,8 @@ pub mod ipld;
 pub mod link;
 pub mod raw;
 pub mod raw_value;
+#[cfg(feature = "serde-codec")]
+pub mod serde;
 
 pub use cid;
 #[cfg(feature = "std")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core ipld types used by ipld codecs.
 #![deny(missing_docs)]
-//#![deny(warnings)]
+#![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -236,7 +236,7 @@ impl<'de> de::Deserializer<'de> for CidDeserializer {
 /// The deserialization will return an error if you try to deserialize into an integer type that
 /// would be too small to hold the value stored in [`Ipld::Integer`].
 ///
-/// [`Ipld::Floats`] are cast, possibly with loss of precision, to the requested Rust type.
+/// [`Ipld::Floats`] can be converted to `f32` if there is no of precision, else it will error.
 impl<'de> de::Deserializer<'de> for Ipld {
     type Error = SerdeError;
 

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
-use std::fmt;
+use alloc::{borrow::ToOwned, collections::BTreeMap, format, string::String, vec::Vec};
+use core::fmt;
 
 use cid::serde::{BytesToCidVisitor, CID_SERDE_PRIVATE_IDENTIFIER};
 use cid::Cid;

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -285,14 +285,12 @@ impl<'de> de::Deserializer<'de> for Ipld {
     fn deserialize_f32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         match self {
             Self::Float(float) => {
-                if float.is_finite() {
-                    if (float as f32) as f64 == float {
-                        visitor.visit_f32(float as f32)
-                    } else {
-                        error("`Ipld::Float` cannot be deserialized to `f32`, without loss of precision`")
-                    }
-                } else {
+                if !float.is_finite() {
                     error(format!("`Ipld::Float` must be a finite number, not infinity or NaN, input was `{}`", float))
+                } else if (float as f32) as f64 != float {
+                    error("`Ipld::Float` cannot be deserialized to `f32`, without loss of precision`")
+                } else {
+                    visitor.visit_f32(float as f32)
                 }
             }
             _ => error(format!(

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -442,20 +442,11 @@ impl<'de> de::Deserializer<'de> for Ipld {
     fn deserialize_struct<V: de::Visitor<'de>>(
         self,
         _name: &str,
-        fields: &[&str],
+        _fields: &[&str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self {
-            Self::Map(map) => {
-                let keys: Vec<_> = map.keys().collect();
-                let mut fields_sorted = fields.to_vec();
-                fields_sorted.sort_unstable();
-                if keys == fields_sorted {
-                    visit_map(map, visitor)
-                } else {
-                    error("Struct fields must match the keys of the `Ipld::Map`")
-                }
-            }
+            Self::Map(map) => visit_map(map, visitor),
             _ => error(format!(
                 "Only `Ipld::Map` can be deserialized to struct, input was `{:#?}`",
                 self

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -1,0 +1,713 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use cid::serde::{BytesToCidVisitor, CID_SERDE_PRIVATE_IDENTIFIER};
+use cid::Cid;
+use serde::{
+    de::{self, IntoDeserializer},
+    forward_to_deserialize_any,
+};
+
+use crate::error::SerdeError;
+use crate::ipld::Ipld;
+
+/// Deserialize instances of [`crate::ipld::Ipld`].
+///
+/// # Example
+///
+/// ```
+/// use std::collections::BTreeMap;
+///
+/// use serde::Deserialize;
+/// use libipld_core::ipld::Ipld;
+/// use libipld_core::serde::from_ipld;
+///
+/// #[derive(Deserialize)]
+/// struct Person {
+///     name: String,
+///     age: u8,
+///     hobbies: Vec<String>,
+///     is_cool: bool,
+/// }
+///
+/// let ipld = Ipld::Map({
+///     BTreeMap::from([
+///         ("name".into(), Ipld::String("Hello World!".into())),
+///         ("age".into(), Ipld::Integer(52)),
+///         (
+///             "hobbies".into(),
+///             Ipld::List(vec![
+///                 Ipld::String("geography".into()),
+///                 Ipld::String("programming".into()),
+///             ]),
+///         ),
+///         ("is_cool".into(), Ipld::Bool(true)),
+///     ])
+/// });
+///
+/// let person = from_ipld(ipld);
+/// assert!(matches!(person, Ok(Person { .. })));
+/// ```
+// NOTE vmx 2021-12-22: Taking by value is also what `serde_json` does.
+pub fn from_ipld<T>(value: Ipld) -> Result<T, SerdeError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    T::deserialize(value)
+}
+
+impl<'de> de::Deserialize<'de> for Ipld {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct IpldVisitor;
+
+        impl<'de> de::Visitor<'de> for IpldVisitor {
+            type Value = Ipld;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.write_str("any valid IPLD kind")
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::String(String::from(value)))
+            }
+
+            #[inline]
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_byte_buf(v.to_owned())
+            }
+
+            #[inline]
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Bytes(v))
+            }
+
+            #[inline]
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Integer(v.into()))
+            }
+
+            #[inline]
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Integer(v.into()))
+            }
+
+            #[inline]
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Integer(v))
+            }
+
+            #[inline]
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Float(v))
+            }
+
+            #[inline]
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Bool(v))
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_unit()
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Ipld::Null)
+            }
+
+            #[inline]
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Ipld::List(vec))
+            }
+
+            #[inline]
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut values = BTreeMap::new();
+
+                while let Some((key, value)) = visitor.next_entry()? {
+                    values.insert(key, value);
+                }
+
+                Ok(Ipld::Map(values))
+            }
+
+            /// Newtype structs are only used to deserialize CIDs.
+            #[inline]
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                deserializer
+                    .deserialize_bytes(BytesToCidVisitor)
+                    .map(Ipld::Link)
+            }
+        }
+
+        deserializer.deserialize_any(IpldVisitor)
+    }
+}
+
+macro_rules! impl_deserialize_integer {
+    ($ty:ident, $deserialize:ident, $visit:ident) => {
+        fn $deserialize<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+            match self {
+                Self::Integer(integer) => {
+                    if integer >= $ty::MIN.into() && integer <= $ty::MAX.into() {
+                        visitor.$visit(integer as $ty)
+                    } else {
+                        error(format!(
+                            "`Ipld::Integer` value was bigger than `{}`",
+                            stringify!($ty)
+                        ))
+                    }
+                }
+                _ => error(format!(
+                    "Only `Ipld::Integer` can be deserialized to `{}`, input was `{:#?}`",
+                    stringify!($ty),
+                    self
+                )),
+            }
+        }
+    };
+}
+
+/// A Deserializer for CIDs.
+///
+/// A separate deserializer is needed to make sure we always deserialize only CIDs as `Ipld::Link`
+/// and don't deserialize arbitrary bytes.
+struct CidDeserializer(Cid);
+
+impl<'de> de::Deserializer<'de> for CidDeserializer {
+    type Error = SerdeError;
+
+    #[inline]
+    fn deserialize_any<V: de::Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        unreachable!()
+    }
+
+    fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_bytes(&self.0.to_bytes())
+    }
+
+    forward_to_deserialize_any! {
+        bool byte_buf char enum f32 f64  i8 i16 i32 i64 identifier ignored_any map newtype_struct
+        option seq str string struct tuple tuple_struct  u8 u16 u32 u64 unit unit_struct
+    }
+}
+
+/// Deserialize from an [`Ipld`] enum into a Rust type.
+///
+/// The deserialization will return an error if you try to deserialize into an integer type that
+/// would be too small to hold the value stored in [`Ipld::Integer`].
+///
+/// [`Ipld::Floats`] are cast, possibly with loss of precision, to the requested Rust type.
+impl<'de> de::Deserializer<'de> for Ipld {
+    type Error = SerdeError;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Null => visitor.visit_unit(),
+            Self::Bool(bool) => visitor.visit_bool(bool),
+            Self::Integer(i128) => visitor.visit_i128(i128),
+            Self::Float(f64) => visitor.visit_f64(f64),
+            Self::String(string) => visitor.visit_str(&string),
+            Self::Bytes(bytes) => visitor.visit_bytes(&bytes),
+            Self::List(list) => visit_seq(list, visitor),
+            Self::Map(map) => visit_map(map, visitor),
+            Self::Link(cid) => visitor.visit_newtype_struct(CidDeserializer(cid)),
+        }
+    }
+
+    fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Null => visitor.visit_unit(),
+            _ => error(format!(
+                "Only `Ipld::Null` can be deserialized to unit, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_bool<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Bool(bool) => visitor.visit_bool(bool),
+            _ => error(format!(
+                "Only `Ipld::Bool` can be deserialized to bool, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    impl_deserialize_integer!(i8, deserialize_i8, visit_i8);
+    impl_deserialize_integer!(i16, deserialize_i16, visit_i16);
+    impl_deserialize_integer!(i32, deserialize_i32, visit_i32);
+    impl_deserialize_integer!(i64, deserialize_i64, visit_i64);
+
+    impl_deserialize_integer!(u8, deserialize_u8, visit_u8);
+    impl_deserialize_integer!(u16, deserialize_u16, visit_u16);
+    impl_deserialize_integer!(u32, deserialize_u32, visit_u32);
+    impl_deserialize_integer!(u64, deserialize_u64, visit_u64);
+
+    fn deserialize_f32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Float(float) => visitor.visit_f32(float as f32),
+            _ => error(format!(
+                "Only `Ipld::Float` can be deserialized to `f32`, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_f64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Float(float) => visitor.visit_f64(float),
+            _ => error(format!(
+                "Only `Ipld::Float` can be deserialized to `f64`, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::String(string) => {
+                if string.len() == 1 {
+                    visitor.visit_char(string.chars().next().unwrap())
+                } else {
+                    error("`Ipld::String` was longer than a single character")
+                }
+            }
+            _ => error(format!(
+                "Only `Ipld::String` can be deserialized to string, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_str<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::String(string) => visitor.visit_str(&string),
+            _ => error(format!(
+                "Only `Ipld::String` can be deserialized to string, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::String(string) => visitor.visit_string(string),
+            _ => error(format!(
+                "Only `Ipld::String` can be deserialized to string, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Bytes(bytes) => visitor.visit_bytes(&bytes),
+            _ => error(format!(
+                "Only `Ipld::Bytes` can be deserialized to bytes, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_byte_buf<V: de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Bytes(bytes) => visitor.visit_byte_buf(bytes),
+            _ => error(format!(
+                "Only `Ipld::Bytes` can be deserialized to bytes, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_seq<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::List(list) => visit_seq(list, visitor),
+            _ => error(format!(
+                "Only `Ipld::List` can be deserialized to sequence, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_tuple<V: de::Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Map(map) => visit_map(map, visitor),
+            _ => error(format!(
+                "Only `Ipld::Map` can be deserialized to map, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_identifier<V: de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::String(string) => visitor.visit_str(&string),
+            _ => error(format!(
+                "Only `Ipld::String` can be deserialized to identifier, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &str,
+        _fields: &[&str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Map(map) => visit_map(map, visitor),
+            _ => error(format!(
+                "Only `Ipld::Map` can be deserialized to struct, input was `{:#?}`",
+                self
+            )),
+        }
+    }
+
+    fn deserialize_unit_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        name: &str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        if name == CID_SERDE_PRIVATE_IDENTIFIER {
+            match self {
+                Ipld::Link(cid) => visitor.visit_newtype_struct(CidDeserializer(cid)),
+                _ => error(format!(
+                    "Only `Ipld::Link`s can be deserialized to CIDs, input was `{:#?}`",
+                    self
+                )),
+            }
+        } else {
+            visitor.visit_newtype_struct(self)
+        }
+    }
+
+    // Heavily based on
+    // https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L249
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        _name: &str,
+        _variants: &[&str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        let (variant, value) = match self {
+            Ipld::Map(map) => {
+                let mut iter = map.into_iter();
+                let (variant, value) = match iter.next() {
+                    Some(v) => v,
+                    None => {
+                        return error(
+                            "Only `Ipld::Map`s with a single key can be deserialized to `enum`, input had no keys"
+                        );
+                    }
+                };
+                // Enums are encoded in IPLD as maps with a single key-value pair
+                if iter.next().is_some() {
+                    return error(
+                        "Only `Ipld::Map`s with a single key can be deserialized to `enum`, input had more keys"
+                    );
+                }
+                (variant, Some(value))
+            }
+            Ipld::String(variant) => (variant, None),
+            _ => return error(format!(
+                    "Only `Ipld::Map` and `Ipld::String` can be deserialized to `enum`, input was `{:#?}`",
+                    self
+            )),
+        };
+
+        visitor.visit_enum(EnumDeserializer { variant, value })
+    }
+
+    // Heavily based on
+    // https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L446
+    fn deserialize_ignored_any<V: de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        drop(self);
+        visitor.visit_unit()
+    }
+
+    fn deserialize_option<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self {
+            Self::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+}
+
+fn visit_map<'de, V>(map: BTreeMap<String, Ipld>, visitor: V) -> Result<V::Value, SerdeError>
+where
+    V: de::Visitor<'de>,
+{
+    let mut deserializer = MapDeserializer::new(map);
+    visitor.visit_map(&mut deserializer)
+}
+
+fn visit_seq<'de, V>(list: Vec<Ipld>, visitor: V) -> Result<V::Value, SerdeError>
+where
+    V: de::Visitor<'de>,
+{
+    let mut deserializer = SeqDeserializer::new(list);
+    visitor.visit_seq(&mut deserializer)
+}
+
+// Heavily based on
+// https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L601
+struct MapDeserializer {
+    iter: <BTreeMap<String, Ipld> as IntoIterator>::IntoIter,
+    value: Option<Ipld>,
+}
+
+impl MapDeserializer {
+    fn new(map: BTreeMap<String, Ipld>) -> Self {
+        Self {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for MapDeserializer {
+    type Error = SerdeError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                seed.deserialize(Ipld::String(key)).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(value),
+            None => error("value is missing"),
+        }
+    }
+}
+
+// Heavily based on
+// https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L554
+struct SeqDeserializer {
+    iter: <Vec<Ipld> as IntoIterator>::IntoIter,
+}
+
+impl SeqDeserializer {
+    fn new(vec: Vec<Ipld>) -> Self {
+        Self {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for SeqDeserializer {
+    type Error = SerdeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+// Heavily based on
+// https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L455
+struct EnumDeserializer {
+    variant: String,
+    value: Option<Ipld>,
+}
+
+impl<'de> de::EnumAccess<'de> for EnumDeserializer {
+    type Error = SerdeError;
+    type Variant = VariantDeserializer;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantDeserializer(self.value);
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+// Heavily based on
+// https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/de.rs#L482
+struct VariantDeserializer(Option<Ipld>);
+
+impl<'de> de::VariantAccess<'de> for VariantDeserializer {
+    type Error = SerdeError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.0 {
+            Some(value) => de::Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.0 {
+            Some(value) => seed.deserialize(value),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.0 {
+            Some(Ipld::List(v)) => {
+                if v.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_seq(v, visitor)
+                }
+            }
+            Some(_) => error(format!(
+                "Only `Ipld::List` can be deserialized to tuple variant, input was `{:#?}`",
+                self.0
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.0 {
+            Some(Ipld::Map(v)) => visit_map(v, visitor),
+            Some(_) => error(format!(
+                "Only `Ipld::Map` can be deserialized to struct variant, input was `{:#?}`",
+                self.0
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+/// Returns a general error.
+fn error<S, T>(message: S) -> Result<T, SerdeError>
+where
+    S: AsRef<str> + fmt::Display,
+{
+    Err(de::Error::custom(message))
+}

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -218,7 +218,7 @@ impl<'de> de::Deserializer<'de> for CidDeserializer {
 
     #[inline]
     fn deserialize_any<V: de::Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        unreachable!()
+        error("Only bytes can be deserialized into a CID")
     }
 
     fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {

--- a/core/src/serde/mod.rs
+++ b/core/src/serde/mod.rs
@@ -8,37 +8,32 @@ mod ser;
 pub use de::from_ipld;
 pub use ser::to_ipld;
 
-use std::fmt;
-
-use serde::{de::DeserializeOwned, Serialize};
-
-use crate::ipld::Ipld;
-
-/// Utility for testing (de)serialization of [`Ipld`].
-///
-/// Checks if `data` and `ipld` match if they are encoded into each other.
-pub fn assert_roundtrip<T>(data: &T, ipld: &Ipld)
-where
-    T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
-{
-    let encoded: Ipld = to_ipld(&data).unwrap();
-    assert_eq!(&encoded, ipld);
-    let decoded: T = from_ipld(ipld.clone()).unwrap();
-    assert_eq!(&decoded, data);
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
     use std::convert::TryFrom;
+    use std::fmt;
 
     use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
     use cid::Cid;
-    use serde::{Deserialize, Serialize};
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
     use serde_test::{assert_tokens, Token};
 
     use crate::ipld::Ipld;
-    use crate::serde::{assert_roundtrip, from_ipld};
+    use crate::serde::{from_ipld, to_ipld};
+
+    /// Utility for testing (de)serialization of [`Ipld`].
+    ///
+    /// Checks if `data` and `ipld` match if they are encoded into each other.
+    fn assert_roundtrip<T>(data: &T, ipld: &Ipld)
+    where
+        T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
+    {
+        let encoded: Ipld = to_ipld(&data).unwrap();
+        assert_eq!(&encoded, ipld);
+        let decoded: T = from_ipld(ipld.clone()).unwrap();
+        assert_eq!(&decoded, data);
+    }
 
     #[derive(Debug, Deserialize, PartialEq, Serialize)]
     struct Person {

--- a/core/src/serde/mod.rs
+++ b/core/src/serde/mod.rs
@@ -1,0 +1,140 @@
+//! Serde (de)serializtion for [`crate::ipld::Ipld`].
+//!
+//! This implementation enables Serde to serialize to/deserialize from [`crate::ipld::Ipld`]
+//! values. The `Ipld` enum is similar to the `Value` enum in `serde_json` or `serde_cbor`.
+mod de;
+mod ser;
+
+pub use de::from_ipld;
+pub use ser::to_ipld;
+
+use std::fmt;
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::ipld::Ipld;
+
+/// Utility for testing (de)serialization of [`Ipld`].
+///
+/// Checks if `data` and `ipld` match if they are encoded into each other.
+pub fn assert_roundtrip<T>(data: &T, ipld: &Ipld)
+where
+    T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
+{
+    let encoded: Ipld = to_ipld(&data).unwrap();
+    assert_eq!(&encoded, ipld);
+    let decoded: T = from_ipld(ipld.clone()).unwrap();
+    assert_eq!(&decoded, data);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::convert::TryFrom;
+
+    use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
+    use cid::Cid;
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_tokens, Token};
+
+    use crate::ipld::Ipld;
+    use crate::serde::{assert_roundtrip, from_ipld};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Person {
+        name: String,
+        age: u8,
+        hobbies: Vec<String>,
+        is_cool: bool,
+        link: Cid,
+    }
+
+    impl Default for Person {
+        fn default() -> Self {
+            Self {
+                name: "Hello World!".into(),
+                age: 52,
+                hobbies: vec!["geography".into(), "programming".into()],
+                is_cool: true,
+                link: Cid::try_from("bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily")
+                    .unwrap(),
+            }
+        }
+    }
+
+    #[test]
+    fn test_tokens() {
+        let person = Person::default();
+
+        assert_tokens(
+            &person,
+            &[
+                Token::Struct {
+                    name: "Person",
+                    len: 5,
+                },
+                Token::Str("name"),
+                Token::Str("Hello World!"),
+                Token::Str("age"),
+                Token::U8(52),
+                Token::Str("hobbies"),
+                Token::Seq { len: Some(2) },
+                Token::Str("geography"),
+                Token::Str("programming"),
+                Token::SeqEnd,
+                Token::Str("is_cool"),
+                Token::Bool(true),
+                Token::Str("link"),
+                Token::NewtypeStruct {
+                    name: CID_SERDE_PRIVATE_IDENTIFIER,
+                },
+                Token::Bytes(&[
+                    0x01, 0x71, 0x12, 0x20, 0x35, 0x4d, 0x45, 0x5f, 0xf3, 0xa6, 0x41, 0xb8, 0xca,
+                    0xc2, 0x5c, 0x38, 0xa7, 0x7e, 0x64, 0xaa, 0x73, 0x5d, 0xc8, 0xa4, 0x89, 0x66,
+                    0xa6, 0xf, 0x1a, 0x78, 0xca, 0xa1, 0x72, 0xa4, 0x88, 0x5e,
+                ]),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    /// Test if converting to a struct from [`crate::ipld::Ipld`] and back works.
+    #[test]
+    fn test_ipld() {
+        let person = Person::default();
+
+        let expected_ipld = Ipld::Map({
+            BTreeMap::from([
+                ("name".into(), Ipld::String("Hello World!".into())),
+                ("age".into(), Ipld::Integer(52)),
+                (
+                    "hobbies".into(),
+                    Ipld::List(vec![
+                        Ipld::String("geography".into()),
+                        Ipld::String("programming".into()),
+                    ]),
+                ),
+                ("is_cool".into(), Ipld::Bool(true)),
+                ("link".into(), Ipld::Link(person.link)),
+            ])
+        });
+
+        assert_roundtrip(&person, &expected_ipld);
+    }
+
+    /// Test that deserializing arbitrary bytes are not accidently recognized as CID.
+    #[test]
+    fn test_bytes_not_cid() {
+        let cid =
+            Cid::try_from("bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily").unwrap();
+
+        let bytes_not_cid = Ipld::Bytes(cid.to_bytes());
+        let not_a_cid: Result<Cid, _> = from_ipld(bytes_not_cid);
+        assert!(not_a_cid.is_err());
+
+        // Make sure that a Ipld::Link deserializes correctly though.
+        let link = Ipld::Link(cid);
+        let a_cid: Cid = from_ipld(link).unwrap();
+        assert_eq!(a_cid, cid);
+    }
+}

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -51,14 +51,14 @@ impl ser::Serialize for Ipld {
     {
         match &self {
             Self::Null => serializer.serialize_unit(),
-            Self::Bool(bool) => serializer.serialize_bool(*bool),
-            Self::Integer(i128) => serializer.serialize_i128(*i128),
-            Self::Float(f64) => serializer.serialize_f64(*f64),
-            Self::String(string) => serializer.serialize_str(string),
-            Self::Bytes(bytes) => serializer.serialize_bytes(bytes),
-            Self::List(list) => serializer.collect_seq(list),
-            Self::Map(map) => serializer.collect_map(map),
-            Self::Link(link) => link.serialize(serializer),
+            Self::Bool(value) => serializer.serialize_bool(*value),
+            Self::Integer(value) => serializer.serialize_i128(*value),
+            Self::Float(value) => serializer.serialize_f64(*value),
+            Self::String(value) => serializer.serialize_str(value),
+            Self::Bytes(value) => serializer.serialize_bytes(value),
+            Self::List(value) => serializer.collect_seq(value),
+            Self::Map(value) => serializer.collect_map(value),
+            Self::Link(value) => value.serialize(serializer),
         }
     }
 }

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -206,8 +206,7 @@ impl serde::Serializer for Serializer {
     where
         T: ser::Serialize,
     {
-        let mut values = BTreeMap::new();
-        values.insert(variant.to_owned(), value.serialize(self)?);
+        let values = BTreeMap::from([(variant.to_owned(), value.serialize(self)?)]);
         Ok(Self::Ok::Map(values))
     }
 
@@ -370,11 +369,8 @@ impl ser::SerializeTupleVariant for SerializeTupleVariant {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        let mut object = BTreeMap::new();
-
-        object.insert(self.name, Self::Ok::List(self.vec));
-
-        Ok(Self::Ok::Map(object))
+        let map = BTreeMap::from([(self.name, Self::Ok::List(self.vec))]);
+        Ok(Self::Ok::Map(map))
     }
 }
 

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -56,7 +56,7 @@ impl ser::Serialize for Ipld {
         S: ser::Serializer,
     {
         match &self {
-            Self::Null => serializer.serialize_unit(),
+            Self::Null => serializer.serialize_none(),
             Self::Bool(value) => serializer.serialize_bool(*value),
             Self::Integer(value) => serializer.serialize_i128(*value),
             Self::Float(value) => serializer.serialize_f64(*value),

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -108,22 +108,22 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_i128(value.into())
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_i128(value.into())
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_i128(value.into())
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
-        Ok(Self::Ok::Integer(value.into()))
+        self.serialize_i128(value.into())
     }
 
     #[inline]

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -1,6 +1,12 @@
 // Parts of this code is based on
 // https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/ser.rs
-use alloc::collections::BTreeMap;
+use alloc::{
+    borrow::ToOwned,
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::convert::TryFrom;
 
 use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -1,0 +1,454 @@
+// Parts of this code is based on
+// https://github.com/serde-rs/json/blob/95f67a09399d546d9ecadeb747a845a77ff309b2/src/value/ser.rs
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+
+use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
+use cid::Cid;
+use serde::ser;
+
+use crate::error::SerdeError;
+use crate::ipld::Ipld;
+
+/// Serialize into instances of [`crate::ipld::Ipld`].
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use libipld_core::ipld::Ipld;
+/// use libipld_core::serde::to_ipld;
+///
+/// #[derive(Serialize)]
+/// struct Person {
+///     name: String,
+///     age: u8,
+///     hobbies: Vec<String>,
+///     is_cool: bool,
+/// }
+///
+/// let person = Person {
+///     name: "Hello World!".into(),
+///     age: 52,
+///     hobbies: vec!["geography".into(), "programming".into()],
+///     is_cool: true,
+/// };
+///
+/// let ipld = to_ipld(person);
+/// assert!(matches!(ipld, Ok(Ipld::Map(_))));
+/// ```
+pub fn to_ipld<T>(value: T) -> Result<Ipld, SerdeError>
+where
+    T: ser::Serialize,
+{
+    value.serialize(Serializer)
+}
+
+impl ser::Serialize for Ipld {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match &self {
+            Self::Null => serializer.serialize_unit(),
+            Self::Bool(bool) => serializer.serialize_bool(*bool),
+            Self::Integer(i128) => serializer.serialize_i128(*i128),
+            Self::Float(f64) => serializer.serialize_f64(*f64),
+            Self::String(string) => serializer.serialize_str(string),
+            Self::Bytes(bytes) => serializer.serialize_bytes(bytes),
+            Self::List(list) => serializer.collect_seq(list),
+            Self::Map(map) => serializer.collect_map(map),
+            Self::Link(link) => link.serialize(serializer),
+        }
+    }
+}
+
+struct Serializer;
+
+impl serde::Serializer for Serializer {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    type SerializeSeq = SerializeVec;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeStructVariant;
+
+    #[inline]
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Bool(value))
+    }
+
+    #[inline]
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    #[inline]
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    #[inline]
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(i64::from(value))
+    }
+
+    #[inline]
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i128(i128::from(value))
+    }
+
+    fn serialize_i128(self, value: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Integer(value))
+    }
+
+    #[inline]
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    #[inline]
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    #[inline]
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(u64::from(value))
+    }
+
+    #[inline]
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Integer(value.into()))
+    }
+
+    #[inline]
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_f64(f64::from(value))
+    }
+
+    #[inline]
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Float(value))
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(&value.to_string())
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Bytes(value.to_vec()))
+    }
+
+    #[inline]
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Null)
+    }
+
+    #[inline]
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        let ipld = value.serialize(self);
+        if name == CID_SERDE_PRIVATE_IDENTIFIER {
+            if let Ok(Ipld::Bytes(bytes)) = ipld {
+                let cid = Cid::try_from(bytes)
+                    .map_err(|err| ser::Error::custom(format!("Invalid CID: {}", err)))?;
+                return Ok(Self::Ok::Link(cid));
+            }
+        }
+        ipld
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        let mut values = BTreeMap::new();
+        values.insert(variant.to_owned(), value.serialize(self)?);
+        Ok(Self::Ok::Map(values))
+    }
+
+    #[inline]
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(SerializeVec {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_tuple(len)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(SerializeTupleVariant {
+            name: String::from(variant),
+            vec: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(SerializeMap {
+            map: BTreeMap::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(SerializeStructVariant {
+            name: String::from(variant),
+            map: BTreeMap::new(),
+        })
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+pub struct SerializeVec {
+    vec: Vec<Ipld>,
+}
+
+pub struct SerializeTupleVariant {
+    name: String,
+    vec: Vec<Ipld>,
+}
+
+pub struct SerializeMap {
+    map: BTreeMap<String, Ipld>,
+    next_key: Option<String>,
+}
+
+pub struct SerializeStructVariant {
+    name: String,
+    map: BTreeMap<String, Ipld>,
+}
+
+impl ser::SerializeSeq for SerializeVec {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        self.vec.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::List(self.vec))
+    }
+}
+
+impl ser::SerializeTuple for SerializeVec {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        self.vec.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut object = BTreeMap::new();
+
+        object.insert(self.name, Self::Ok::List(self.vec));
+
+        Ok(Self::Ok::Map(object))
+    }
+}
+
+impl ser::SerializeMap for SerializeMap {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        match key.serialize(Serializer)? {
+            Ipld::String(string_key) => {
+                self.next_key = Some(string_key);
+                Ok(())
+            }
+            _ => Err(ser::Error::custom("Map keys must be strings".to_string())),
+        }
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        let key = self.next_key.take();
+        // Panic because this indicates a bug in the program rather than an
+        // expected failure.
+        let key = key.expect("serialize_value called before serialize_key");
+        self.map.insert(key, value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Self::Ok::Map(self.map))
+    }
+}
+
+impl ser::SerializeStruct for SerializeMap {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        serde::ser::SerializeMap::serialize_key(self, key)?;
+        serde::ser::SerializeMap::serialize_value(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeMap::end(self)
+    }
+}
+
+impl ser::SerializeStructVariant for SerializeStructVariant {
+    type Ok = Ipld;
+    type Error = SerdeError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        self.map
+            .insert(key.to_string(), value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut object = BTreeMap::new();
+
+        object.insert(self.name, Self::Ok::Map(self.map));
+
+        Ok(Self::Ok::Map(object))
+    }
+}

--- a/core/tests/serde_deserialize.rs
+++ b/core/tests/serde_deserialize.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "serde-codec")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+
+use serde_test::{assert_de_tokens, Token};
+
+use libipld_core::cid::{serde::CID_SERDE_PRIVATE_IDENTIFIER, Cid};
+use libipld_core::ipld::Ipld;
+
+#[test]
+fn ipld_deserialize_null() {
+    let ipld = Ipld::Null;
+    assert_de_tokens(&ipld, &[Token::None]);
+    assert_de_tokens(&ipld, &[Token::Unit]);
+    assert_de_tokens(&ipld, &[Token::UnitStruct { name: "foo" }]);
+}
+
+#[test]
+fn ipld_deserialize_bool() {
+    let bool = true;
+    let ipld = Ipld::Bool(bool);
+    assert_de_tokens(&ipld, &[Token::Bool(bool)]);
+}
+
+#[test]
+fn ipld_deserialize_integer_u() {
+    let integer = 32u8;
+    let ipld = Ipld::Integer(integer.into());
+    assert_de_tokens(&ipld, &[Token::U8(integer)]);
+    assert_de_tokens(&ipld, &[Token::U16(integer.into())]);
+    assert_de_tokens(&ipld, &[Token::U32(integer.into())]);
+    assert_de_tokens(&ipld, &[Token::U64(integer.into())]);
+}
+
+#[test]
+fn ipld_deserialize_integer_i() {
+    let integer = -32i8;
+    let ipld = Ipld::Integer(integer.into());
+    assert_de_tokens(&ipld, &[Token::I8(integer)]);
+    assert_de_tokens(&ipld, &[Token::I16(integer.into())]);
+    assert_de_tokens(&ipld, &[Token::I32(integer.into())]);
+    assert_de_tokens(&ipld, &[Token::I64(integer.into())]);
+}
+
+#[test]
+fn ipld_deserialize_float() {
+    let float = 32.41f32;
+    let ipld = Ipld::Float(float.into());
+    assert_de_tokens(&ipld, &[Token::F32(float)]);
+    assert_de_tokens(&ipld, &[Token::F64(float.into())]);
+}
+
+#[test]
+fn ipld_deserialize_string() {
+    let string = "hello";
+    let ipld = Ipld::String(string.into());
+    assert_de_tokens(&ipld, &[Token::Str(string)]);
+    assert_de_tokens(&ipld, &[Token::BorrowedStr(string)]);
+    assert_de_tokens(&ipld, &[Token::String(string)]);
+}
+
+#[test]
+fn ipld_deserialize_string_char() {
+    let char = 'h';
+    let ipld = Ipld::String(char.into());
+    assert_de_tokens(&ipld, &[Token::Char(char)]);
+}
+
+#[test]
+fn ipld_deserialize_bytes() {
+    let bytes = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::Bytes(bytes);
+    assert_de_tokens(&ipld, &[Token::Bytes(b"hello")]);
+    assert_de_tokens(&ipld, &[Token::BorrowedBytes(b"hello")]);
+    assert_de_tokens(&ipld, &[Token::ByteBuf(b"hello")]);
+}
+
+#[test]
+fn ipld_deserialize_list() {
+    let ipld = Ipld::List(vec![Ipld::Bool(false), Ipld::Float(22.7)]);
+    assert_de_tokens(
+        &ipld,
+        &[
+            Token::Seq { len: Some(2) },
+            Token::Bool(false),
+            Token::F64(22.7),
+            Token::SeqEnd,
+        ],
+    );
+}
+
+#[test]
+fn ipld_deserialize_map() {
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".to_string(), Ipld::Bool(true)),
+        ("world!".to_string(), Ipld::Bool(false)),
+    ]));
+    assert_de_tokens(
+        &ipld,
+        &[
+            Token::Map { len: Some(2) },
+            Token::Str("hello"),
+            Token::Bool(true),
+            Token::Str("world!"),
+            Token::Bool(false),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn ipld_deserialize_link() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    assert_de_tokens(
+        &ipld,
+        &[
+            Token::NewtypeStruct {
+                name: CID_SERDE_PRIVATE_IDENTIFIER,
+            },
+            Token::Bytes(&[
+                1, 85, 18, 32, 159, 228, 204, 198, 222, 22, 114, 79, 58, 48, 199, 232, 242, 84,
+                243, 198, 71, 25, 134, 172, 177, 248, 216, 207, 142, 150, 206, 42, 215, 219, 231,
+                251,
+            ]),
+        ],
+    );
+}
+
+#[test]
+#[should_panic(expected = "assertion failed")]
+fn ipld_deserialize_link_not_as_bytes() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    assert_de_tokens(
+        &ipld,
+        &[Token::Bytes(&[
+            1, 85, 18, 32, 159, 228, 204, 198, 222, 22, 114, 79, 58, 48, 199, 232, 242, 84, 243,
+            198, 71, 25, 134, 172, 177, 248, 216, 207, 142, 150, 206, 42, 215, 219, 231, 251,
+        ])],
+    );
+}

--- a/core/tests/serde_deserialize.rs
+++ b/core/tests/serde_deserialize.rs
@@ -14,7 +14,19 @@ use libipld_core::ipld::Ipld;
 fn ipld_deserialize_null() {
     let ipld = Ipld::Null;
     assert_de_tokens(&ipld, &[Token::None]);
+}
+
+#[test]
+#[should_panic(expected = "invalid type")]
+fn ipld_deserialize_null_not_as_unit() {
+    let ipld = Ipld::Null;
     assert_de_tokens(&ipld, &[Token::Unit]);
+}
+
+#[test]
+#[should_panic(expected = "invalid type")]
+fn ipld_deserialize_null_not_as_unit_struct() {
+    let ipld = Ipld::Null;
     assert_de_tokens(&ipld, &[Token::UnitStruct { name: "foo" }]);
 }
 

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -421,6 +421,31 @@ fn ipld_deserializer_cid() {
     assert_eq!(deserialized, cid);
 }
 
+/// Make sure that a CID cannot be deserialized into bytes.
+#[test]
+fn ipld_deserializer_cid_not_bytes() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    error_except(cid, &ipld);
+
+    let deserialized = ByteBuf::deserialize(ipld);
+    assert!(deserialized.is_err());
+}
+
+/// Make sure that a CID cannot be deserialized into bytes.
+#[test]
+fn ipld_deserializer_cid_not_bytes_newtype_struct() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct Wrapped(ByteBuf);
+
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    error_except(cid, &ipld);
+
+    let deserialized = Wrapped::deserialize(ipld);
+    assert!(deserialized.is_err());
+}
+
 #[test]
 fn ipld_deserializer_newtype_struct() {
     #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -571,4 +596,15 @@ fn ipld_deserializer_struct_errors() {
     error_except(my_struct, &ipld_additional);
     let error_additional = MyStruct::deserialize(ipld_additional);
     assert!(error_additional.is_err());
+}
+
+/// This tests excercises the `deserialize_any` code path.
+#[test]
+fn ipld_deserializer_ipld() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    error_except(cid, &ipld);
+
+    let deserialized = Ipld::deserialize(ipld.clone()).unwrap();
+    assert_eq!(deserialized, ipld);
 }

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -56,12 +56,9 @@ where
 #[test]
 #[allow(clippy::unit_cmp)]
 fn ipld_deserializer_unit() {
-    let unit = ();
     let ipld = Ipld::Null;
-    error_except(unit, &ipld);
-
-    let deserialized = <()>::deserialize(ipld).unwrap();
-    assert_eq!(deserialized, unit);
+    let deserialized = <()>::deserialize(ipld);
+    assert!(deserialized.is_err());
 }
 
 #[test]
@@ -69,12 +66,9 @@ fn ipld_deserializer_unit_struct() {
     #[derive(Clone, Debug, Deserialize, PartialEq)]
     struct UnitStruct;
 
-    let unit_struct = UnitStruct;
     let ipld = Ipld::Null;
-    error_except(unit_struct.clone(), &ipld);
-
-    let deserialized = UnitStruct::deserialize(ipld).unwrap();
-    assert_eq!(deserialized, unit_struct);
+    let deserialized = UnitStruct::deserialize(ipld);
+    assert!(deserialized.is_err());
 }
 
 #[test]
@@ -332,10 +326,10 @@ fn ipld_deserializer_tuple() {
 #[test]
 fn ipld_deserializer_tuple_struct() {
     #[derive(Clone, Debug, Deserialize, PartialEq)]
-    struct TupleStruct(u8, ());
+    struct TupleStruct(u8, bool);
 
-    let tuple_struct = TupleStruct(82, ());
-    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Null]);
+    let tuple_struct = TupleStruct(82, true);
+    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Bool(true)]);
     error_except(tuple_struct.clone(), &ipld);
 
     let deserialized = TupleStruct::deserialize(ipld).unwrap();
@@ -369,10 +363,10 @@ fn ipld_deserializer_cid() {
 #[test]
 fn ipld_deserializer_newtype_struct() {
     #[derive(Clone, Debug, Deserialize, PartialEq)]
-    struct Wrapped(());
+    struct Wrapped(u8);
 
-    let newtype_struct = Wrapped(());
-    let ipld = Ipld::Null;
+    let newtype_struct = Wrapped(5);
+    let ipld = Ipld::Integer(5);
     error_except(newtype_struct.clone(), &ipld);
 
     let deserialized = Wrapped::deserialize(ipld).unwrap();

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -1,0 +1,480 @@
+#![cfg(feature = "serde-codec")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+
+use serde::Deserialize;
+use serde_bytes::ByteBuf;
+
+use libipld_core::cid::Cid;
+use libipld_core::ipld::Ipld;
+
+/// This function is to test that all IPLD kinds except the given one errors, when trying to
+/// deserialize to the given Rust type.
+fn error_except<'de, T>(_input: T, except: &Ipld)
+where
+    T: Deserialize<'de> + core::fmt::Debug,
+{
+    if !matches!(except, Ipld::Null) {
+        assert!(T::deserialize(Ipld::Null).is_err());
+    }
+    if !matches!(except, Ipld::Bool(_)) {
+        assert!(T::deserialize(Ipld::Bool(true)).is_err());
+    }
+    if !matches!(except, Ipld::Integer(_)) {
+        assert!(T::deserialize(Ipld::Integer(22)).is_err());
+    }
+    if !matches!(except, Ipld::Float(_)) {
+        assert!(T::deserialize(Ipld::Float(5.3)).is_err());
+    }
+    if !matches!(except, Ipld::String(_)) {
+        assert!(T::deserialize(Ipld::String("hello".into())).is_err());
+    }
+    if !matches!(except, Ipld::Bytes(_)) {
+        assert!(T::deserialize(Ipld::Bytes(vec![0x68, 0x65, 0x6c, 0x6c, 0x6f])).is_err());
+    }
+    if !matches!(except, Ipld::List(_)) {
+        assert!(T::deserialize(Ipld::List(vec![Ipld::Integer(22), Ipld::Bool(false)])).is_err());
+    }
+    if !matches!(except, Ipld::Map(_)) {
+        assert!(T::deserialize(Ipld::Map(BTreeMap::from([
+            ("hello".into(), Ipld::Null),
+            ("world!".into(), Ipld::Float(7.4))
+        ])))
+        .is_err());
+    }
+    if !matches!(except, Ipld::Link(_)) {
+        assert!(T::deserialize(Ipld::Link(
+            Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap()
+        ))
+        .is_err());
+    }
+}
+
+#[test]
+#[allow(clippy::unit_cmp)]
+fn ipld_deserializer_unit() {
+    let unit = ();
+    let ipld = Ipld::Null;
+    error_except(unit, &ipld);
+
+    let deserialized = <()>::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, unit);
+}
+
+#[test]
+fn ipld_deserializer_unit_struct() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct UnitStruct;
+
+    let unit_struct = UnitStruct;
+    let ipld = Ipld::Null;
+    error_except(unit_struct.clone(), &ipld);
+
+    let deserialized = UnitStruct::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, unit_struct);
+}
+
+#[test]
+fn ipld_deserializer_bool() {
+    let bool = false;
+    let ipld = Ipld::Bool(bool);
+    error_except(bool, &ipld);
+
+    let deserialized = bool::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, bool);
+}
+
+#[test]
+fn ipld_deserializer_u8() {
+    let integer = 34u8;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = u8::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to u8."
+    );
+
+    let too_large = u8::deserialize(Ipld::Integer((u8::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = u8::deserialize(Ipld::Integer((u8::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_u16() {
+    let integer = 345u16;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = u16::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to u16."
+    );
+
+    let too_large = u16::deserialize(Ipld::Integer((u16::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = u16::deserialize(Ipld::Integer((u16::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_u32() {
+    let integer = 345678u32;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = u32::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to u32."
+    );
+
+    let too_large = u32::deserialize(Ipld::Integer((u32::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = u32::deserialize(Ipld::Integer((u32::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_u64() {
+    let integer = 34567890123u64;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = u64::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to u64."
+    );
+
+    let too_large = u64::deserialize(Ipld::Integer((u64::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = u64::deserialize(Ipld::Integer((u64::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_i8() {
+    let integer = -23i8;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = i8::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to i8."
+    );
+
+    let too_large = i8::deserialize(Ipld::Integer((i8::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = i8::deserialize(Ipld::Integer((i8::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_i16() {
+    let integer = 2345i16;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = i16::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to i16."
+    );
+
+    let too_large = i16::deserialize(Ipld::Integer((i16::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = i16::deserialize(Ipld::Integer((i16::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_i32() {
+    let integer = 234567i32;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = i32::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to i32."
+    );
+
+    let too_large = i32::deserialize(Ipld::Integer((i32::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = i32::deserialize(Ipld::Integer((i32::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_i64() {
+    let integer = 2345678901i64;
+    let ipld = Ipld::Integer(integer.into());
+    error_except(integer, &ipld);
+
+    let deserialized = i64::deserialize(ipld).unwrap();
+    assert_eq!(
+        deserialized, integer,
+        "Correctly deserialize Ipld::Integer to i64."
+    );
+
+    let too_large = i64::deserialize(Ipld::Integer((i64::MAX as i128) + 10));
+    assert!(too_large.is_err(), "Number must be within range.");
+    let too_small = i64::deserialize(Ipld::Integer((i64::MIN as i128) - 10));
+    assert!(too_small.is_err(), "Number must be within range.");
+}
+
+#[test]
+fn ipld_deserializer_f32() {
+    let float = 7.3f32;
+    let ipld = Ipld::Float(float.into());
+    error_except(float, &ipld);
+
+    let deserialized = f32::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, float);
+}
+
+#[test]
+fn ipld_deserializer_f64() {
+    let float = 427.8f64;
+    let ipld = Ipld::Float(float);
+    error_except(float, &ipld);
+
+    let deserialized = f64::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, float);
+}
+
+#[test]
+fn ipld_deserializer_char() {
+    let char = 'x';
+    let ipld = Ipld::String(char.to_string());
+    error_except(char, &ipld);
+
+    let deserialized = char::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, char);
+}
+
+#[test]
+fn ipld_deserializer_str() {
+    let str: &str = "hello";
+    let ipld = Ipld::String(str.to_string());
+    error_except(str, &ipld);
+
+    // TODO vmx 2022-02-09: Doesn't work yet. If we would have a zero-copy version, it should
+    //let deserialized = <&str>::deserialize(ipld).unwrap();
+    //assert_eq!(deserialized, string);
+}
+
+#[test]
+fn ipld_deserializer_string() {
+    let string = "hello".to_string();
+    let ipld = Ipld::String(string.clone());
+    error_except(string.clone(), &ipld);
+
+    let deserialized = String::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, string);
+}
+
+#[test]
+fn ipld_deserializer_bytes() {
+    let bytes = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::Bytes(bytes.clone());
+    error_except(&bytes[..], &ipld);
+
+    // TODO vmx 2022-02-09: Doesn't work yet. If we would have a zero-copy version, it should
+    //let deserialized = <&[u8]>::deserialize(ipld).unwrap();
+    //assert_eq!(deserialized, bytes);
+}
+
+#[test]
+fn ipld_deserializer_byte_buf() {
+    let bytes = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::Bytes(bytes.clone());
+    error_except(ByteBuf::from(bytes.clone()), &ipld);
+
+    let deserialized = ByteBuf::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, bytes);
+}
+
+#[test]
+fn ipld_deserializer_list() {
+    let list = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::List(vec![
+        Ipld::Integer(0x68),
+        Ipld::Integer(0x65),
+        Ipld::Integer(0x6c),
+        Ipld::Integer(0x6c),
+        Ipld::Integer(0x6f),
+    ]);
+    error_except(list.clone(), &ipld);
+
+    let deserialized = Vec::<u8>::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, list);
+}
+
+#[test]
+fn ipld_deserializer_tuple() {
+    let tuple = (true, "hello".to_string());
+    let ipld = Ipld::List(vec![Ipld::Bool(tuple.0), Ipld::String(tuple.1.clone())]);
+    error_except(tuple.clone(), &ipld);
+
+    let deserialized = <(bool, String)>::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, tuple);
+}
+
+#[test]
+fn ipld_deserializer_tuple_struct() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct TupleStruct(u8, ());
+
+    let tuple_struct = TupleStruct(82, ());
+    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Null]);
+    error_except(tuple_struct.clone(), &ipld);
+
+    let deserialized = TupleStruct::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, tuple_struct);
+}
+
+#[test]
+fn ipld_deserializer_map() {
+    let map = BTreeMap::from([("hello".to_string(), true), ("world!".to_string(), false)]);
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".to_string(), Ipld::Bool(true)),
+        ("world!".to_string(), Ipld::Bool(false)),
+    ]));
+    error_except(map.clone(), &ipld);
+
+    let deserialized = BTreeMap::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, map);
+}
+
+/// A CID is deserialized through a newtype struct.
+#[test]
+fn ipld_deserializer_cid() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    error_except(cid, &ipld);
+
+    let deserialized = Cid::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, cid);
+}
+
+#[test]
+fn ipld_deserializer_newtype_struct() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct Wrapped(());
+
+    let newtype_struct = Wrapped(());
+    let ipld = Ipld::Null;
+    error_except(newtype_struct.clone(), &ipld);
+
+    let deserialized = Wrapped::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, newtype_struct);
+}
+
+/// An additional test, just to make sure that wrapped CIDs also work.
+#[test]
+fn ipld_deserializer_newtype_struct_cid() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct Wrapped(Cid);
+
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let newtype_struct = Wrapped(cid);
+    let ipld = Ipld::Link(cid);
+    error_except(newtype_struct.clone(), &ipld);
+
+    let deserialized = Wrapped::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, newtype_struct);
+}
+
+#[test]
+fn ipld_deserializer_option() {
+    let option_some: Option<u8> = Some(58u8);
+    let option_none: Option<u8> = None;
+    let ipld_some = Ipld::Integer(option_some.unwrap().into());
+    let ipld_none = Ipld::Null;
+
+    // This is similar to `error_except`, which cannot be used here, as we need to excluse
+    // `Ipld::Integer` *and* `Ipld::Null`.
+    assert!(<Option<u8>>::deserialize(Ipld::Bool(true)).is_err());
+    assert!(<Option<u8>>::deserialize(Ipld::Float(5.3)).is_err());
+    assert!(<Option<u8>>::deserialize(Ipld::String("hello".into())).is_err());
+    assert!(<Option<u8>>::deserialize(Ipld::Bytes(vec![0x01, 0x97])).is_err());
+    assert!(
+        <Option<u8>>::deserialize(Ipld::List(vec![Ipld::Integer(22), Ipld::Bool(false)])).is_err()
+    );
+    assert!(<Option<u8>>::deserialize(Ipld::Map(BTreeMap::from([
+        ("hello".into(), Ipld::Null),
+        ("world!".into(), Ipld::Float(7.4))
+    ])))
+    .is_err());
+    assert!(<Option<u8>>::deserialize(Ipld::Link(
+        Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap()
+    ))
+    .is_err());
+
+    let deserialized_some = <Option<u8>>::deserialize(ipld_some).unwrap();
+    assert_eq!(deserialized_some, option_some);
+    let deserialized_none = <Option<u8>>::deserialize(ipld_none).unwrap();
+    assert_eq!(deserialized_none, option_none);
+}
+
+#[test]
+fn ipld_deserializer_enum() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    enum MyEnum {
+        One,
+        Two(u8),
+        Three { value: bool },
+    }
+
+    let enum_one = MyEnum::One;
+    let ipld_one = Ipld::String("One".into());
+    error_except(enum_one.clone(), &ipld_one);
+    let deserialized_one = MyEnum::deserialize(ipld_one).unwrap();
+    assert_eq!(deserialized_one, enum_one);
+
+    let enum_two = MyEnum::Two(4);
+    let ipld_two = Ipld::Map(BTreeMap::from([("Two".into(), Ipld::Integer(4))]));
+    error_except(enum_two.clone(), &ipld_two);
+    let deserialized_two = MyEnum::deserialize(ipld_two).unwrap();
+    assert_eq!(deserialized_two, enum_two);
+
+    let enum_three = MyEnum::Three { value: true };
+    let ipld_three = Ipld::Map(BTreeMap::from([(
+        "Three".into(),
+        Ipld::Map(BTreeMap::from([("value".into(), Ipld::Bool(true))])),
+    )]));
+    error_except(enum_three.clone(), &ipld_three);
+    let deserialized_three = MyEnum::deserialize(ipld_three).unwrap();
+    assert_eq!(deserialized_three, enum_three);
+}
+
+#[test]
+fn ipld_deserializer_struct() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct MyStruct {
+        hello: u8,
+        world: bool,
+    }
+
+    let my_struct = MyStruct {
+        hello: 91,
+        world: false,
+    };
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".into(), Ipld::Integer(my_struct.hello.into())),
+        ("world".into(), Ipld::Bool(my_struct.world)),
+    ]));
+    error_except(my_struct.clone(), &ipld);
+
+    let deserialized = MyStruct::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, my_struct);
+}

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -7,6 +7,7 @@ use core::convert::TryFrom;
 
 use serde::Deserialize;
 use serde_bytes::ByteBuf;
+use serde_json::json;
 
 use libipld_core::cid::Cid;
 use libipld_core::ipld::Ipld;
@@ -607,4 +608,25 @@ fn ipld_deserializer_ipld() {
 
     let deserialized = Ipld::deserialize(ipld.clone()).unwrap();
     assert_eq!(deserialized, ipld);
+}
+
+/// This test shows that the values [`serde_json::Value`] supports, can be deserialized into Ipld
+#[test]
+fn ipld_deserializer_serde_json_value() {
+    let json_value = json!({ "hello": true, "world": "it is" });
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".into(), Ipld::Bool(true)),
+        ("world".into(), Ipld::String("it is".into())),
+    ]));
+    let deserialized = serde_json::Value::deserialize(ipld).unwrap();
+    assert_eq!(deserialized, json_value);
+}
+
+/// This test shows that CIDs cannot be deserialized into a [`serde_json::Value`].
+#[test]
+fn ipld_deserializer_serde_json_value_cid_fails() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    let error = serde_json::Value::deserialize(ipld);
+    assert!(error.is_err());
 }

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -649,18 +649,9 @@ fn ipld_deserializer_struct_errors() {
         "wrong".into(),
         Ipld::Integer(my_struct.hello.into()),
     )]));
-    error_except(my_struct.clone(), &ipld_wrong);
+    error_except(my_struct, &ipld_wrong);
     let error_wrong = MyStruct::deserialize(ipld_wrong);
     assert!(error_wrong.is_err());
-
-    let ipld_additional = Ipld::Map(BTreeMap::from([
-        ("hello".into(), Ipld::Integer(my_struct.hello.into())),
-        ("world".into(), Ipld::Bool(my_struct.world)),
-        ("more".into(), Ipld::String("data".into())),
-    ]));
-    error_except(my_struct, &ipld_additional);
-    let error_additional = MyStruct::deserialize(ipld_additional);
-    assert!(error_additional.is_err());
 }
 
 /// This tests excercises the `deserialize_any` code path.

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -477,6 +477,24 @@ fn ipld_deserializer_cid_not_bytes_newtype_struct() {
     assert!(deserialized.is_err());
 }
 
+/// Make sure that a CID cannot be deserialized into bytes.
+#[test]
+fn ipld_deserializer_cid_untagged() {
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    #[serde(untagged)]
+    enum MyOption {
+        Some(ByteBuf),
+        None,
+    }
+
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    error_except(cid, &ipld);
+
+    let deserialized = MyOption::deserialize(ipld);
+    assert!(deserialized.is_err());
+}
+
 #[test]
 fn ipld_deserializer_newtype_struct() {
     #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/core/tests/serde_serialize.rs
+++ b/core/tests/serde_serialize.rs
@@ -13,7 +13,7 @@ use libipld_core::ipld::Ipld;
 #[test]
 fn ipld_serialize_null() {
     let ipld = Ipld::Null;
-    assert_ser_tokens(&ipld, &[Token::Unit]);
+    assert_ser_tokens(&ipld, &[Token::None]);
 }
 
 #[test]

--- a/core/tests/serde_serialize.rs
+++ b/core/tests/serde_serialize.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "serde-codec")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+
+use serde_test::{assert_ser_tokens, Token};
+
+use libipld_core::cid::{serde::CID_SERDE_PRIVATE_IDENTIFIER, Cid};
+use libipld_core::ipld::Ipld;
+
+#[test]
+fn ipld_serialize_null() {
+    let ipld = Ipld::Null;
+    assert_ser_tokens(&ipld, &[Token::Unit]);
+}
+
+#[test]
+fn ipld_serialize_bool() {
+    let bool = true;
+    let ipld = Ipld::Bool(bool);
+    assert_ser_tokens(&ipld, &[Token::Bool(bool)]);
+}
+
+// NOTE vmx 2022-02-15: assert_ser_tokens doesn't support i128
+//#[test]
+//fn ipld_serialize_integer() {
+//   let integer = 32u8;
+//   let ipld = Ipld::Integer(integer.into());
+//}
+
+#[test]
+fn ipld_serialize_float() {
+    let float = 32.41f32;
+    let ipld = Ipld::Float(float.into());
+    assert_ser_tokens(&ipld, &[Token::F64(float.into())]);
+}
+
+#[test]
+fn ipld_serialize_string() {
+    let string = "hello";
+    let ipld = Ipld::String(string.into());
+    assert_ser_tokens(&ipld, &[Token::Str(string)]);
+    assert_ser_tokens(&ipld, &[Token::BorrowedStr(string)]);
+    assert_ser_tokens(&ipld, &[Token::String(string)]);
+}
+
+#[test]
+fn ipld_serialize_bytes() {
+    let bytes = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::Bytes(bytes);
+    assert_ser_tokens(&ipld, &[Token::Bytes(b"hello")]);
+    assert_ser_tokens(&ipld, &[Token::BorrowedBytes(b"hello")]);
+    assert_ser_tokens(&ipld, &[Token::ByteBuf(b"hello")]);
+}
+
+#[test]
+fn ipld_serialize_list() {
+    let ipld = Ipld::List(vec![Ipld::Bool(false), Ipld::Float(22.7)]);
+    assert_ser_tokens(
+        &ipld,
+        &[
+            Token::Seq { len: Some(2) },
+            Token::Bool(false),
+            Token::F64(22.7),
+            Token::SeqEnd,
+        ],
+    );
+}
+
+#[test]
+fn ipld_serialize_map() {
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".to_string(), Ipld::Bool(true)),
+        ("world!".to_string(), Ipld::Bool(false)),
+    ]));
+    assert_ser_tokens(
+        &ipld,
+        &[
+            Token::Map { len: Some(2) },
+            Token::Str("hello"),
+            Token::Bool(true),
+            Token::Str("world!"),
+            Token::Bool(false),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn ipld_serialize_link() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    assert_ser_tokens(
+        &ipld,
+        &[
+            Token::NewtypeStruct {
+                name: CID_SERDE_PRIVATE_IDENTIFIER,
+            },
+            Token::Bytes(&[
+                1, 85, 18, 32, 159, 228, 204, 198, 222, 22, 114, 79, 58, 48, 199, 232, 242, 84,
+                243, 198, 71, 25, 134, 172, 177, 248, 216, 207, 142, 150, 206, 42, 215, 219, 231,
+                251,
+            ]),
+        ],
+    );
+}
+
+#[test]
+#[should_panic(expected = "expected Token::Bytes")]
+fn ipld_serialize_link_not_as_bytes() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    assert_ser_tokens(
+        &ipld,
+        &[Token::Bytes(&[
+            1, 85, 18, 32, 159, 228, 204, 198, 222, 22, 114, 79, 58, 48, 199, 232, 242, 84, 243,
+            198, 71, 25, 134, 172, 177, 248, 216, 207, 142, 150, 206, 42, 215, 219, 231, 251,
+        ])],
+    );
+}

--- a/core/tests/serde_serializer.rs
+++ b/core/tests/serde_serializer.rs
@@ -23,8 +23,8 @@ where
 #[test]
 fn ipld_serializer_unit() {
     let unit = ();
-    let ipld = Ipld::Null;
-    assert_serialized(unit, ipld);
+    let serialized = to_ipld(unit);
+    assert!(serialized.is_err());
 }
 
 #[test]
@@ -33,8 +33,8 @@ fn ipld_serializer_unit_struct() {
     struct UnitStruct;
 
     let unit_struct = UnitStruct;
-    let ipld = Ipld::Null;
-    assert_serialized(unit_struct, ipld);
+    let serialized = to_ipld(unit_struct);
+    assert!(serialized.is_err());
 }
 
 #[test]
@@ -165,10 +165,10 @@ fn ipld_serializer_tuple() {
 #[test]
 fn ipld_serializer_tuple_struct() {
     #[derive(Clone, Debug, Serialize, PartialEq)]
-    struct TupleStruct(u8, ());
+    struct TupleStruct(u8, bool);
 
-    let tuple_struct = TupleStruct(82, ());
-    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Null]);
+    let tuple_struct = TupleStruct(82, true);
+    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Bool(true)]);
     assert_serialized(tuple_struct, ipld);
 }
 
@@ -193,10 +193,10 @@ fn ipld_serializer_cid() {
 #[test]
 fn ipld_serializer_newtype_struct() {
     #[derive(Clone, Debug, Serialize, PartialEq)]
-    struct Wrapped(());
+    struct Wrapped(u8);
 
-    let newtype_struct = Wrapped(());
-    let ipld = Ipld::Null;
+    let newtype_struct = Wrapped(3);
+    let ipld = Ipld::Integer(3);
     assert_serialized(newtype_struct, ipld);
 }
 

--- a/core/tests/serde_serializer.rs
+++ b/core/tests/serde_serializer.rs
@@ -1,0 +1,267 @@
+#![cfg(feature = "serde-codec")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+
+use serde::{ser, Serialize};
+use serde_bytes::ByteBuf;
+
+use libipld_core::cid::Cid;
+use libipld_core::ipld::Ipld;
+use libipld_core::serde::to_ipld;
+
+fn assert_serialized<T>(input: T, ipld: Ipld)
+where
+    T: ser::Serialize,
+{
+    let serialized = to_ipld(input).unwrap();
+    assert_eq!(serialized, ipld);
+}
+
+#[test]
+fn ipld_serializer_unit() {
+    let unit = ();
+    let ipld = Ipld::Null;
+    assert_serialized(unit, ipld);
+}
+
+#[test]
+fn ipld_serializer_unit_struct() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct UnitStruct;
+
+    let unit_struct = UnitStruct;
+    let ipld = Ipld::Null;
+    assert_serialized(unit_struct, ipld);
+}
+
+#[test]
+fn ipld_serializer_bool() {
+    let bool = false;
+    let ipld = Ipld::Bool(bool);
+    assert_serialized(bool, ipld);
+}
+
+#[test]
+fn ipld_serializer_u8() {
+    let integer = 34u8;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_u16() {
+    let integer = 345u16;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_u32() {
+    let integer = 345678u32;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_u64() {
+    let integer = 34567890123u64;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_i8() {
+    let integer = -23i8;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_i16() {
+    let integer = 2345i16;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_i32() {
+    let integer = 234567i32;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_i64() {
+    let integer = 2345678901i64;
+    let ipld = Ipld::Integer(integer.into());
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_i128() {
+    let integer = 34567890123467890123i128;
+    let ipld = Ipld::Integer(integer);
+    assert_serialized(integer, ipld);
+}
+
+#[test]
+fn ipld_serializer_f32() {
+    let float = 7.3f32;
+    let ipld = Ipld::Float(float.into());
+    assert_serialized(float, ipld);
+}
+
+#[test]
+fn ipld_serializer_f64() {
+    let float = 427.8f64;
+    let ipld = Ipld::Float(float);
+    assert_serialized(float, ipld);
+}
+
+#[test]
+fn ipld_serializer_char() {
+    let char = 'x';
+    let ipld = Ipld::String(char.to_string());
+    assert_serialized(char, ipld);
+}
+
+#[test]
+fn ipld_serializer_str() {
+    let str: &str = "hello";
+    let ipld = Ipld::String(str.to_string());
+    assert_serialized(str, ipld);
+}
+
+#[test]
+fn ipld_serializer_bytes() {
+    let bytes = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::Bytes(bytes.clone());
+    assert_serialized(ByteBuf::from(bytes), ipld);
+}
+
+#[test]
+fn ipld_serializer_list() {
+    let list = vec![0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let ipld = Ipld::List(vec![
+        Ipld::Integer(0x68),
+        Ipld::Integer(0x65),
+        Ipld::Integer(0x6c),
+        Ipld::Integer(0x6c),
+        Ipld::Integer(0x6f),
+    ]);
+    assert_serialized(list, ipld);
+}
+
+#[test]
+fn ipld_serializer_tuple() {
+    let tuple = (true, "hello".to_string());
+    let ipld = Ipld::List(vec![Ipld::Bool(tuple.0), Ipld::String(tuple.1.clone())]);
+    assert_serialized(tuple, ipld);
+}
+
+#[test]
+fn ipld_serializer_tuple_struct() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct TupleStruct(u8, ());
+
+    let tuple_struct = TupleStruct(82, ());
+    let ipld = Ipld::List(vec![Ipld::Integer(82), Ipld::Null]);
+    assert_serialized(tuple_struct, ipld);
+}
+
+#[test]
+fn ipld_serializer_map() {
+    let map = BTreeMap::from([("hello".to_string(), true), ("world!".to_string(), false)]);
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".to_string(), Ipld::Bool(true)),
+        ("world!".to_string(), Ipld::Bool(false)),
+    ]));
+    assert_serialized(map, ipld);
+}
+
+/// A CID is deserialized through a newtype struct.
+#[test]
+fn ipld_serializer_cid() {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let ipld = Ipld::Link(cid);
+    assert_serialized(cid, ipld);
+}
+
+#[test]
+fn ipld_serializer_newtype_struct() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct Wrapped(());
+
+    let newtype_struct = Wrapped(());
+    let ipld = Ipld::Null;
+    assert_serialized(newtype_struct, ipld);
+}
+
+/// An additional test, just to make sure that wrapped CIDs also work.
+#[test]
+fn ipld_serializer_newtype_struct_cid() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct Wrapped(Cid);
+
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let newtype_struct = Wrapped(cid);
+    let ipld = Ipld::Link(cid);
+    assert_serialized(newtype_struct, ipld);
+}
+
+#[test]
+fn ipld_serializer_option() {
+    let option_some: Option<u8> = Some(58u8);
+    let option_none: Option<u8> = None;
+    let ipld_some = Ipld::Integer(option_some.unwrap().into());
+    let ipld_none = Ipld::Null;
+    assert_serialized(option_some, ipld_some);
+    assert_serialized(option_none, ipld_none);
+}
+
+#[test]
+fn ipld_serializer_enum() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    enum MyEnum {
+        One,
+        Two(u8),
+        Three { value: bool },
+    }
+
+    let enum_one = MyEnum::One;
+    let ipld_one = Ipld::String("One".into());
+    assert_serialized(enum_one, ipld_one);
+
+    let enum_two = MyEnum::Two(4);
+    let ipld_two = Ipld::Map(BTreeMap::from([("Two".into(), Ipld::Integer(4))]));
+    assert_serialized(enum_two, ipld_two);
+
+    let enum_three = MyEnum::Three { value: true };
+    let ipld_three = Ipld::Map(BTreeMap::from([(
+        "Three".into(),
+        Ipld::Map(BTreeMap::from([("value".into(), Ipld::Bool(true))])),
+    )]));
+    assert_serialized(enum_three, ipld_three);
+}
+
+#[test]
+fn ipld_serializer_struct() {
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct MyStruct {
+        hello: u8,
+        world: bool,
+    }
+
+    let my_struct = MyStruct {
+        hello: 91,
+        world: false,
+    };
+    let ipld = Ipld::Map(BTreeMap::from([
+        ("hello".into(), Ipld::Integer(my_struct.hello.into())),
+        ("world".into(), Ipld::Bool(my_struct.world)),
+    ]));
+    assert_serialized(my_struct, ipld);
+}


### PR DESCRIPTION
It's now possible to serialize and deserialize the `Ipld` enum with Serde.
As the Serde data model doesn't support custom types, we use the newtype
struct hack, which is used by many other libraries as well. We introduce
a newtype struct with a mostly unique/hard to clash with name. This struct
wraps the CID.

Serde de(serializers) that support CIDs, can then make use of it, others
will see a strange looking struct in their ouput.