### PR TITLE
Expose serializer

### DIFF
--- a/core/src/serde/mod.rs
+++ b/core/src/serde/mod.rs
@@ -6,7 +6,7 @@ mod de;
 mod ser;
 
 pub use de::from_ipld;
-pub use ser::to_ipld;
+pub use ser::{to_ipld, Serializer};
 
 #[cfg(test)]
 mod tests {

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -99,7 +99,8 @@ impl ser::Serialize for Ipld {
     }
 }
 
-struct Serializer;
+/// The IPLD serializer.
+pub struct Serializer;
 
 impl serde::Serializer for Serializer {
     type Ok = Ipld;


### PR DESCRIPTION
This PR exposes the ipld `Serializer` struct because there are times when one needs to create a custom serialization pipeline. In our case, we needed the serialization to be async.

https://github.com/wnfs-wg/rs-wnfs/blob/8471980856716bbdf54b77cc01fe4b7c350e559b/crates/fs/traits.rs#L67-L73