### PR TITLE
Fix lint-rust action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "library for dealing with ipld"
 repository = "https://github.com/ipld/libipld"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-core"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Base traits and definitions used by ipld codecs."
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -56,6 +56,7 @@ where
 
 #[test]
 #[allow(clippy::unit_cmp)]
+#[allow(clippy::let_unit_value)]
 fn ipld_deserializer_unit() {
     let unit = ();
     let ipld = Ipld::Null;

--- a/core/tests/serde_serializer.rs
+++ b/core/tests/serde_serializer.rs
@@ -21,6 +21,7 @@ where
 }
 
 #[test]
+#[allow(clippy::let_unit_value)]
 fn ipld_serializer_unit() {
     let unit = ();
     let serialized = to_ipld(unit);

--- a/dag-cbor-derive/Cargo.toml
+++ b/dag-cbor-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-cbor-derive"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ipld cbor codec proc macro"
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/dag-cbor-derive/examples/renamed-package/Cargo.toml
+++ b/dag-cbor-derive/examples/renamed-package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "renamed-package"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [package.metadata.release]

--- a/dag-cbor-derive/src/gen.rs
+++ b/dag-cbor-derive/src/gen.rs
@@ -100,7 +100,6 @@ fn gen_encode_struct_body(s: &Struct) -> TokenStream {
             let dfields = s.fields.iter().filter_map(|field| {
                 if let Some(default) = field.default.as_ref() {
                     let binding = &field.binding;
-                    let default = &*default;
                     Some(quote! {
                         if #binding == &#default {
                             len -= 1;

--- a/dag-cbor-derive/src/gen.rs
+++ b/dag-cbor-derive/src/gen.rs
@@ -13,7 +13,7 @@ pub fn gen_encode(ast: &SchemaType, libipld: &syn::Ident) -> TokenStream {
     let trait_name = quote!(#libipld::codec::Encode<#libipld::cbor::DagCborCodec>);
 
     quote! {
-        impl#impl_generics #trait_name for #ident #ty_generics #where_clause {
+        impl #impl_generics #trait_name for #ident #ty_generics #where_clause {
             fn encode<W: std::io::Write>(
                 &self,
                 c: #libipld::cbor::DagCborCodec,
@@ -37,7 +37,7 @@ pub fn gen_decode(ast: &SchemaType, libipld: &syn::Ident) -> TokenStream {
     let trait_name = quote!(#libipld::codec::Decode<#libipld::cbor::DagCborCodec>);
 
     quote! {
-        impl#impl_generics #trait_name for #ident #ty_generics #where_clause {
+        impl #impl_generics #trait_name for #ident #ty_generics #where_clause {
             fn decode<R: std::io::Read + std::io::Seek>(
                 c: #libipld::cbor::DagCborCodec,
                 r: &mut R,

--- a/dag-cbor/Cargo.toml
+++ b/dag-cbor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-cbor"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ipld cbor codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/dag-cbor/src/decode.rs
+++ b/dag-cbor/src/decode.rs
@@ -601,6 +601,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::let_unit_value)]
     fn tuples() -> Result<()> {
         let data = ();
         let bytes = DagCborCodec.encode(&data)?;

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-json"
 version = "0.13.1"
 authors = ["Irakli Gozalishvili <contact@gozala.io>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ipld json codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/ipfs-rust/rust-ipld"
 
 [dependencies]
 libipld-core = { version = "0.13.0", path = "../core" }
-prost = "0.9.0"
+prost = "0.10.0"
 thiserror = "1.0.25"
 
 [build-dependencies]
-prost-build = "0.11.1"
+prost-build = "0.10.0"
 
 [dev-dependencies]
 libipld-macro = { path = "../macro" }

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-pb"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ipld protobuf codec"
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -13,7 +13,7 @@ prost = "0.9.0"
 thiserror = "1.0.25"
 
 [build-dependencies]
-prost-build = "0.9.0"
+prost-build = "0.11.1"
 
 [dev-dependencies]
 libipld-macro = { path = "../macro" }

--- a/dag-pb/src/lib.rs
+++ b/dag-pb/src/lib.rs
@@ -1,6 +1,7 @@
 //! Protobuf codec.
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 pub use crate::codec::{PbLink, PbNode};
 use core::convert::{TryFrom, TryInto};

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libipld-macro"
 version = "0.13.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ipld macro"
 repository = "https://github.com/ipfs-rust/rust-ipld"

--- a/src/path.rs
+++ b/src/path.rs
@@ -58,7 +58,7 @@ impl ToString for Path {
 }
 
 /// Path in a dag.
-#[derive(Clone, Debug, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DagPath<'a>(&'a Cid, Path);
 
 impl<'a> DagPath<'a> {


### PR DESCRIPTION
Work on #150 

This fixes some issues introduced by compiling with rust 1.63 instead of 1.62.

I can't quite figure out the `no_std` problems though. It seems like there's some dependency that re-enables the `std` feature on `serde`, but I don't know which and how to debug it. Here's the output I get from building for a no_std target:

```
$ cargo build --no-default-features --target thumbv6m-none-eabi --manifest-path core/Cargo.toml
   Compiling data-encoding v2.3.2
   Compiling serde v1.0.144
   Compiling anyhow v1.0.62
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv6m-none-eabi` target may not support the standard library
  = note: `std` is required by `serde` because it does not declare `#![no_std]`
```