### PR TITLE
Bump 'prost' version to 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
       if: matrix.platform.host == 'windows-latest'
       run: choco install llvm
 
+    - name: Set LIBCLANG_PATH (Windows)
+      # Windows github action doesn't set the path for clang, so set it
+      # See https://github.com/rust-lang/rust-bindgen/issues/1797
+      if: matrix.os == 'windows'
+      run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1
       with:

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -9,11 +9,12 @@ repository = "https://github.com/ipfs-rust/rust-ipld"
 
 [dependencies]
 libipld-core = { version = "0.14.0", path = "../core" }
-prost = "0.10.0"
+prost = "0.11"
 thiserror = "1.0.25"
 
 [build-dependencies]
-prost-build = "0.10.0"
+prost-build = "0.11"
+protobuf-src = "1.1.0"
 
 [dev-dependencies]
 libipld-macro = { path = "../macro" }

--- a/dag-pb/build.rs
+++ b/dag-pb/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
     prost_build::compile_protos(&["src/dag_pb.proto"], &["src"]).unwrap();
 }


### PR DESCRIPTION
This helps downstream crates to not have duplicate version of 'hashbrown'