### PR TITLE
Optimize link scraping for dag-pb

### DIFF
--- a/dag-pb/build.rs
+++ b/dag-pb/build.rs
@@ -1,3 +1,6 @@
 fn main() {
-    prost_build::compile_protos(&["src/dag_pb.proto"], &["src"]).unwrap();
+    prost_build::Config::new()
+        .bytes(&["."])
+        .compile_protos(&["src/dag_pb.proto"], &["src"])
+        .unwrap();
 }


### PR DESCRIPTION
No more costly detour via IPLD AST.

Basically tell prost to use `Bytes` instead of `Vec<u8>`. That allows prost to parse a message without having to create lots of copies.

Then, add an internal method for link scraping that does not go all the way to IPLD.

The only thing visible from the outside is that PbNode::from_bytes now takes an `impl Buf` instead of a `&[u8]`. I doubt there are many people that care, but if strict compatibility is needed this can also be removed.

Fixes the pb part of #154