### PR TITLE
Get rid of prost-build by vendoring the DAG protobuf representation

### DIFF
--- a/core/src/serde/mod.rs
+++ b/core/src/serde/mod.rs
@@ -29,7 +29,7 @@ mod tests {
     where
         T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
     {
-        let encoded: Ipld = to_ipld(&data).unwrap();
+        let encoded: Ipld = to_ipld(data).unwrap();
         assert_eq!(&encoded, ipld);
         let decoded: T = from_ipld(ipld.clone()).unwrap();
         assert_eq!(&decoded, data);

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -9,11 +9,8 @@ repository = "https://github.com/ipfs-rust/rust-ipld"
 
 [dependencies]
 libipld-core = { version = "0.14.0", path = "../core" }
-prost = "0.10.0"
+prost = "0.11.0"
 thiserror = "1.0.25"
-
-[build-dependencies]
-prost-build = "0.10.0"
 
 [dev-dependencies]
 libipld-macro = { path = "../macro" }

--- a/dag-pb/build.rs
+++ b/dag-pb/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    prost_build::Config::new()
-        .bytes(&["."])
-        .compile_protos(&["src/dag_pb.proto"], &["src"])
-        .unwrap();
-}

--- a/dag-pb/src/codec.rs
+++ b/dag-pb/src/codec.rs
@@ -1,13 +1,10 @@
+use crate::dag_pb;
 use core::convert::{TryFrom, TryInto};
 use libipld_core::cid::Cid;
 use libipld_core::error::{Result, TypeError, TypeErrorType};
 use libipld_core::ipld::Ipld;
 use prost::bytes::{Buf, Bytes};
 use std::collections::BTreeMap;
-
-mod dag_pb {
-    include!(concat!(env!("OUT_DIR"), "/dag_pb.rs"));
-}
 
 /// A protobuf ipld link.
 #[derive(Debug)]

--- a/dag-pb/src/dag_pb.rs
+++ b/dag-pb/src/dag_pb.rs
@@ -1,0 +1,23 @@
+/// An IPFS MerkleDAG Link
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PbLink {
+    /// binary CID (with no multibase prefix) of the target object
+    #[prost(bytes = "bytes", tag = "1")]
+    pub hash: ::prost::bytes::Bytes,
+    /// UTF-8 string name
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    /// cumulative size of target object
+    #[prost(uint64, tag = "3")]
+    pub tsize: u64,
+}
+/// An IPFS MerkleDAG Node
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PbNode {
+    /// refs to other objects
+    #[prost(message, repeated, tag = "2")]
+    pub links: ::prost::alloc::vec::Vec<PbLink>,
+    /// opaque user data
+    #[prost(bytes = "bytes", tag = "1")]
+    pub data: ::prost::bytes::Bytes,
+}

--- a/dag-pb/src/lib.rs
+++ b/dag-pb/src/lib.rs
@@ -13,6 +13,7 @@ use prost::bytes::Bytes;
 use std::io::{Read, Seek, Write};
 
 mod codec;
+mod dag_pb;
 
 /// Protobuf codec.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
@vmx as we discussed this removed the need to generate the Rust representation from the .proto file since it won't change. I left it in for reference.