### PR TITLE
Make the deserializer human-unreadable

### DIFF
--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -539,6 +539,9 @@ impl<'de> de::Deserializer<'de> for Ipld {
             _ => visitor.visit_some(self),
         }
     }
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 fn visit_map<'de, V>(map: BTreeMap<String, Ipld>, visitor: V) -> Result<V::Value, SerdeError>

--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -539,6 +539,7 @@ impl<'de> de::Deserializer<'de> for Ipld {
             _ => visitor.visit_some(self),
         }
     }
+
     fn is_human_readable(&self) -> bool {
         false
     }


### PR DESCRIPTION
Currently, the Serializer sets `is_human_readable` to false, but the Deserializer implicitly sets it to true. This causes issues when other types try to use serde based on this value, as in https://github.com/zcash/pasta_curves/pull/48, so this PR makes them consistently false.