### PR TITLE
chore: fix Android build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
 
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
-      run: cargo install cargo-apk
+      uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+      with:
+        crate: cargo-apk
 
     - name: Build
       if: contains(matrix.platform.target, 'android') == false
@@ -82,7 +84,14 @@ jobs:
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo apk --target ${{ matrix.platform.target }} build --workspace --all-features
+      run: |
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-core
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-cbor
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-macro
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-cbor-derive
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-json
+        cargo apk -- build --all-features --target ${{ matrix.platform.target }} -p libipld-pb
 
     - name: Rust tests
       if: matrix.platform.cross == false


### PR DESCRIPTION
Also cache `cargo-apk` for faster CI run times.