### PR TITLE
fix: improve codec spec compliance

### DIFF
--- a/core/src/serde/de.rs
+++ b/core/src/serde/de.rs
@@ -164,7 +164,10 @@ impl<'de> de::Deserialize<'de> for Ipld {
                 let mut values = BTreeMap::new();
 
                 while let Some((key, value)) = visitor.next_entry()? {
-                    values.insert(key, value);
+                    let prev_value = values.insert(key, value);
+                    if prev_value.is_some() {
+                        return Err(de::Error::custom("Duplicate map key"));
+                    }
                 }
 
                 Ok(Ipld::Map(values))

--- a/dag-cbor/src/error.rs
+++ b/dag-cbor/src/error.rs
@@ -115,3 +115,8 @@ pub struct UnexpectedEof;
 #[derive(Debug, Error)]
 #[error("Invalid Cid prefix: {0}")]
 pub struct InvalidCidPrefix(pub u8);
+
+/// A duplicate key within a map.
+#[derive(Debug, Error)]
+#[error("Duplicate map key.")]
+pub struct DuplicateKey;

--- a/dag-json/src/codec.rs
+++ b/dag-json/src/codec.rs
@@ -198,10 +198,13 @@ impl<'de> de::Visitor<'de> for JsonVisitor {
             }
         }
 
-        let unwrapped = values
-            .into_iter()
-            .map(|(key, WrapperOwned(value))| (key, value))
-            .collect();
+        let mut unwrapped = BTreeMap::new();
+        for (key, WrapperOwned(value)) in values {
+            let prev_value = unwrapped.insert(key, value);
+            if prev_value.is_some() {
+                return Err(SerdeError::custom("duplicate map key".to_string()));
+            }
+        }
         Ok(Ipld::Map(unwrapped))
     }
 


### PR DESCRIPTION
The DAG-CBOR, DAG-JSON and DAG-PB codecs are not more spec compliant. New negative test fixtures were added to https://github.com/ipld/codec-fixtures, with this change all pass.

BREAKING CHANGE: DAG-CBOR, DAG-JSON and DAG-PB encoding and decoding is stricter.

In DAG-CBOR and DAG-JSON now error when duplicated map keys with the same map are encountered.

DAG-PB is now stricter on encoding and decoding. For example are links and data not allowed to be interleaved, they have to be one after another (in any order).

When encoding `Ipld` to DAG-PB, the types now need to match, links need to be ordered.

The DAG-PB will error if unknown data is encountered during decoding.

---

I've made it maximally strict. If there are problems with that let me know. I personally prefer making things strict first and relaxing them if it makes sense later on (so we don't need many breaking changes).

The corresponding codec fixtures PR is at https://github.com/ipld/codec-fixtures/pull/85.