### PR TITLE
chore: remove consolidate-pushes from cargo-release config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/ipld/libipld"
 
 [package.metadata.release]
 consolidate-commits = true
-consolidate-pushes = true
 shared-version = true
 
 [dependencies]


### PR DESCRIPTION
Since cargo-release v0.22 the `consolidate-pushes` option is always enabled, hence it was removed. Update the Cargo.toml so that we can do releases with cargo-release newer than v0.22.