### PR TITLE
Remove unused multihash dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ async-std = { version = "1.9.0", features = ["attributes"] }
 criterion = "0.3.4"
 proptest = "1.0.0"
 model = "0.1.2"
-multihash = "0.18.0"
 
 [features]
 default = ["dag-cbor", "dag-json", "dag-pb", "derive"]


### PR DESCRIPTION
This crate is already specified as part of the library build, with no extra features necessary for test code. Remove the extra reference to minimize the dependencies locked by downstream users.