### PR TITLE
Fix warnings on rustc 1.72

### DIFF
--- a/core/src/codec.rs
+++ b/core/src/codec.rs
@@ -1,6 +1,6 @@
 //! `Ipld` codecs.
 use alloc::{format, string::String, vec::Vec};
-use core::{convert::TryFrom, ops::Deref};
+use core::convert::TryFrom;
 
 use crate::cid::Cid;
 use crate::error::{Result, UnsupportedCodec};
@@ -47,7 +47,7 @@ pub trait Encode<C: Codec> {
 
 impl<C: Codec, T: Encode<C>> Encode<C> for &T {
     fn encode<W: Write>(&self, c: C, w: &mut W) -> Result<()> {
-        self.deref().encode(c, w)
+        T::encode(*self, c, w)
     }
 }
 

--- a/core/src/link.rs
+++ b/core/src/link.rs
@@ -42,10 +42,7 @@ impl<T> fmt::Display for Link<T> {
 
 impl<T> Clone for Link<T> {
     fn clone(&self) -> Self {
-        Self {
-            cid: self.cid,
-            _marker: self._marker,
-        }
+        *self
     }
 }
 

--- a/core/tests/serde_deserializer.rs
+++ b/core/tests/serde_deserializer.rs
@@ -531,7 +531,7 @@ fn ipld_deserializer_newtype_struct_cid() {
 fn ipld_deserializer_option() {
     let option_some: Option<u8> = Some(58u8);
     let option_none: Option<u8> = None;
-    let ipld_some = Ipld::Integer(option_some.unwrap().into());
+    let ipld_some = Ipld::Integer(58);
     let ipld_none = Ipld::Null;
 
     // This is similar to `error_except`, which cannot be used here, as we need to exclude

--- a/core/tests/serde_serializer.rs
+++ b/core/tests/serde_serializer.rs
@@ -217,7 +217,7 @@ fn ipld_serializer_newtype_struct_cid() {
 fn ipld_serializer_option() {
     let option_some: Option<u8> = Some(58u8);
     let option_none: Option<u8> = None;
-    let ipld_some = Ipld::Integer(option_some.unwrap().into());
+    let ipld_some = Ipld::Integer(58);
     let ipld_none = Ipld::Null;
     assert_serialized(option_some, ipld_some);
     assert_serialized(option_none, ipld_none);

--- a/dag-cbor-derive/examples/basic.rs
+++ b/dag-cbor-derive/examples/basic.rs
@@ -52,7 +52,7 @@ fn main() {
 
     assert_roundtrip(DagCborCodec, &TupleStruct::default(), &ipld!([false, 0]));
 
-    assert_roundtrip(DagCborCodec, &UnitStruct::default(), &ipld!(null));
+    assert_roundtrip(DagCborCodec, &UnitStruct, &ipld!(null));
 
     assert_roundtrip(DagCborCodec, &Enum::A, &ipld!({ "A": null }));
 

--- a/dag-cbor/src/cbor.rs
+++ b/dag-cbor/src/cbor.rs
@@ -71,9 +71,9 @@ impl TryFrom<u8> for Major {
         } else if (value >> 5) == MajorKind::Other as u8 {
             match value & 0x1f {
                 // False, True, Null. TODO: Allow undefined?
-                20 | 21 | 22 => (),
+                20..=22 => (),
                 // Floats. TODO: forbid f16 & f32?
-                25 | 26 | 27 => (),
+                25..=27 => (),
                 // Everything is forbidden.
                 _ => {
                     return Err(UnexpectedCode::new::<Ipld>(value));


### PR DESCRIPTION
Due to `#![deny(warnings)]` these are needed to develop on the project with the latest release.

```
error: using `.deref()` on a double reference, which returns `&T` instead of dereferencing the inner type
  --> core/src/codec.rs:50:13
   |
50 |         self.deref().encode(c, w)
   |             ^^^^^^^^
   |
note: the lint level is defined here
  --> core/src/lib.rs:3:9
   |
3  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(suspicious_double_ref_op)]` implied by `#[deny(warnings)]`
```

```
Error:   --> dag-cbor/src/cbor.rs:74:17
   |
74 |                 20 | 21 | 22 => (),
   |                 ^^^^^^^^^^^^ help: try: `20..=22`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_patterns
note: the lint level is defined here
  --> dag-cbor/src/lib.rs:3:9
   |
3  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(clippy::manual_range_patterns)]` implied by `#[deny(warnings)]`
```


```
error: incorrect implementation of `clone` on a `Copy` type
  --> core/src/link.rs:44:29
   |
44 |       fn clone(&self) -> Self {
   |  _____________________________^
45 | |         Self {
46 | |             cid: self.cid,
47 | |             _marker: self._marker,
48 | |         }
49 | |     }
   | |_____^ help: change this to: `{ *self }`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_clone_impl_on_copy_type
   = note: `#[deny(clippy::incorrect_clone_impl_on_copy_type)]` on by default
```

```
error: use of `default` to create a unit struct
  --> dag-cbor-derive/examples/basic.rs:55:47
   |
55 |     assert_roundtrip(DagCborCodec, &UnitStruct::default(), &ipld!(null));
   |                                               ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`
```

```
error: used `unwrap()` on `Some` value
   --> core/tests/serde_deserializer.rs:534:35
    |
534 |     let ipld_some = Ipld::Integer(option_some.unwrap().into());
    |                                   ^^^^^^^^^^^^^^^^^^^^
    |
help: remove the `Some` and `unwrap()`
   --> core/tests/serde_deserializer.rs:532:35
    |
532 |     let option_some: Option<u8> = Some(58u8);
    |                                   ^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_literal_unwrap
    = note: `-D clippy::unnecessary-literal-unwrap` implied by `-D warnings`
```