### PR TITLE
chore: use workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,31 @@
 [package]
 name = "libipld"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "library for dealing with ipld"
-repository = "https://github.com/ipld/libipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [package.metadata.release]
 consolidate-commits = true
 shared-version = true
 
 [dependencies]
-fnv = "1.0.7"
-libipld-cbor = { version = "0.16.0", path = "dag-cbor", optional = true }
-libipld-cbor-derive = { version = "0.16.0", path = "dag-cbor-derive", optional = true }
-libipld-core = { version = "0.16.0", path = "core" }
-libipld-json = { version = "0.16.0", path = "dag-json", optional = true }
-libipld-macro = { version = "0.16.0", path = "macro" }
-libipld-pb = { version = "0.16.0", path = "dag-pb", optional = true }
-log = "0.4.14"
-multihash = { version = "0.18.0", default-features = false, features = ["multihash-impl"] }
-thiserror = "1.0.25"
+libipld-cbor = { workspace = true, optional = true }
+libipld-cbor-derive = { workspace = true, optional = true }
+libipld-core = { workspace = true }
+libipld-json = { workspace = true, optional = true }
+libipld-macro = { workspace = true }
+libipld-pb = { workspace = true, optional = true }
+
+multihash = { workspace = true, features = ["multihash-impl"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
-criterion = "0.3.4"
-proptest = "1.0.0"
-model = "0.1.2"
+ahash = { workspace = true }
+criterion = { workspace = true }
+multihash = { workspace = true, features = ["blake3"] }
 
 [features]
 default = ["dag-cbor", "dag-json", "dag-pb", "derive"]
@@ -48,6 +46,49 @@ members = [
   "macro",
   "dag-cbor-derive/examples/renamed-package",
 ]
+resolver = "2"
+
+[workspace.package]
+version = "0.16.0"
+authors = ["David Craven <david@craven.ch>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/ipld/libipld"
+
+[workspace.dependencies]
+libipld = { path = "." }
+libipld-cbor = { path = "dag-cbor" }
+libipld-cbor-derive = { path = "dag-cbor-derive" }
+libipld-core = { path = "core" }
+libipld-json = { path = "dag-json" }
+libipld-macro = { path = "macro" }
+libipld-pb = { path = "dag-pb" }
+
+# External dependencies
+ahash = "0.8"
+anyhow = { version = "1", default-features = false }
+byteorder = "1"
+bytes = "1"
+cid = { version = "0.10", default-features = false, features = ["alloc"] }
+core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+criterion = "0.5"
+hex = "0.4"
+multibase = { version = "0.9", default-features = false }
+multihash = { version = "0.18", default-features = false, features = ["alloc"] }
+proc-macro-crate = "1"
+proc-macro2 = "1"
+quick-protobuf = "0.8"
+quickcheck = "1"
+quote = "1"
+serde = { version = "1", default-features = false, features = ["alloc"] }
+serde_bytes = "0.11"
+serde_cbor = "0.11"
+serde_json = "1"
+serde_test = "1"
+syn = "1"
+synstructure = "0.12"
+thiserror = "2"
+trybuild = "1"
 
 [profile.release]
 debug = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,31 +1,30 @@
 [package]
 name = "libipld-core"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "Base traits and definitions used by ipld codecs."
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 default = ["std"]
 std = ["anyhow/std", "cid/std", "multibase/std", "multihash/std", "thiserror"]
-serde-codec = ["cid/serde-codec", "serde"]
-arb = ["quickcheck", "cid/arb"]
+serde-codec = ["cid/serde-codec", "dep:serde"]
+arb = ["dep:quickcheck", "cid/arb"]
 
 [dependencies]
-anyhow = { version = "1.0.40", default-features = false }
-cid = { version = "0.10.0", default-features = false, features = ["alloc"] }
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
-multihash = { version = "0.18.0", default-features = false, features = ["alloc"] }
-
-multibase = { version = "0.9.1", default-features = false, optional = true }
-serde = { version = "1.0.132", default-features = false, features = ["alloc"], optional = true }
-thiserror = {version = "1.0.25", optional = true }
-quickcheck = { version = "1.0", optional = true }
+anyhow = { workspace = true }
+cid = { workspace = true }
+core2 = { workspace = true }
+multibase = { workspace = true }
+multihash = { workspace = true }
+quickcheck = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
-multihash = { version = "0.18.0", default-features = false, features = ["multihash-impl", "blake3"] }
-serde_test = "1.0.132"
-serde_bytes = "0.11.5"
-serde_json = "1.0.79"
+multihash = { workspace = true, features = ["multihash-impl", "blake3"] }
+serde_bytes = { workspace = true }
+serde_json = { workspace = true }
+serde_test = { workspace = true }

--- a/core/src/serde/ser.rs
+++ b/core/src/serde/ser.rs
@@ -208,14 +208,11 @@ impl serde::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T: ser::Serialize + ?Sized>(
         self,
         name: &'static str,
         value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    ) -> Result<Self::Ok, Self::Error> {
         let ipld = value.serialize(self);
         if name == CID_SERDE_PRIVATE_IDENTIFIER {
             if let Ok(Ipld::Bytes(bytes)) = ipld {
@@ -227,16 +224,13 @@ impl serde::Serializer for Serializer {
         ipld
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T: ser::Serialize + ?Sized>(
         self,
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    ) -> Result<Self::Ok, Self::Error> {
         let values = BTreeMap::from([(variant.to_owned(), value.serialize(self)?)]);
         Ok(Self::Ok::Map(values))
     }
@@ -247,10 +241,10 @@ impl serde::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_some<T: ser::Serialize + ?Sized>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
         value.serialize(self)
     }
 
@@ -342,10 +336,10 @@ impl ser::SerializeSeq for SerializeVec {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_element<T: ser::Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         self.vec.push(value.serialize(Serializer)?);
         Ok(())
     }
@@ -359,10 +353,10 @@ impl ser::SerializeTuple for SerializeVec {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_element<T: ser::Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
@@ -375,10 +369,10 @@ impl ser::SerializeTupleStruct for SerializeVec {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_field<T: ser::Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
@@ -391,10 +385,10 @@ impl ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_field<T: ser::Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         self.vec.push(value.serialize(Serializer)?);
         Ok(())
     }
@@ -409,10 +403,7 @@ impl ser::SerializeMap for SerializeMap {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_key<T: ser::Serialize + ?Sized>(&mut self, key: &T) -> Result<(), Self::Error> {
         match key.serialize(Serializer)? {
             Ipld::String(string_key) => {
                 self.next_key = Some(string_key);
@@ -422,10 +413,10 @@ impl ser::SerializeMap for SerializeMap {
         }
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    fn serialize_value<T: ser::Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         let key = self.next_key.take();
         // Panic because this indicates a bug in the program rather than an
         // expected failure.
@@ -443,14 +434,11 @@ impl ser::SerializeStruct for SerializeMap {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T: ser::Serialize + ?Sized>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    ) -> Result<(), Self::Error> {
         serde::ser::SerializeMap::serialize_key(self, key)?;
         serde::ser::SerializeMap::serialize_value(self, value)
     }
@@ -464,14 +452,11 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = Ipld;
     type Error = SerdeError;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T: ser::Serialize + ?Sized>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: ser::Serialize,
-    {
+    ) -> Result<(), Self::Error> {
         self.map
             .insert(key.to_string(), value.serialize(Serializer)?);
         Ok(())

--- a/dag-cbor-derive/Cargo.toml
+++ b/dag-cbor-derive/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "libipld-cbor-derive"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "ipld cbor codec proc macro"
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "1.1.0"
-proc-macro2 = "1.0.27"
-quote = "1.0.9"
-syn = "1.0.72"
-synstructure = "0.12.4"
+proc-macro-crate = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+synstructure = { workspace = true }
 
 [dev-dependencies]
-libipld = { path = ".." }
-trybuild = "1.0.42"
+libipld = { workspace = true }
+trybuild = { workspace = true }

--- a/dag-cbor-derive/examples/basic.rs
+++ b/dag-cbor-derive/examples/basic.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use libipld::cbor::DagCborCodec;
 use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor, Ipld};

--- a/dag-cbor-derive/examples/name_attr.rs
+++ b/dag-cbor-derive/examples/name_attr.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use libipld::cbor::DagCborCodec;
 use libipld::codec::{Decode, Encode};
 use libipld::ipld::Ipld;

--- a/dag-cbor-derive/examples/renamed-package/Cargo.toml
+++ b/dag-cbor-derive/examples/renamed-package/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 release = false
 
 [dependencies]
-ipld = { path = "../../../", package = "libipld"}
+ipld = { path = "../../../", package = "libipld" }

--- a/dag-cbor-derive/examples/renamed-package/src/lib.rs
+++ b/dag-cbor-derive/examples/renamed-package/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 //! The purpose of this example is to test whether the derive compiles if the libipld package was
 //! renamed in the `Cargo.toml` file.
 use ipld::DagCbor;

--- a/dag-cbor-derive/examples/repr_attr.rs
+++ b/dag-cbor-derive/examples/repr_attr.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use libipld::cbor::DagCborCodec;
 use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor};

--- a/dag-cbor-derive/src/attr.rs
+++ b/dag-cbor-derive/src/attr.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 

--- a/dag-cbor-derive/tests/struct.rs
+++ b/dag-cbor-derive/tests/struct.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use libipld::cbor::{DagCbor, DagCborCodec};
 use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor};

--- a/dag-cbor-derive/tests/union.rs
+++ b/dag-cbor-derive/tests/union.rs
@@ -1,3 +1,5 @@
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use libipld::cbor::DagCborCodec;
 use libipld::codec::assert_roundtrip;
 use libipld::{ipld, DagCbor};

--- a/dag-cbor/Cargo.toml
+++ b/dag-cbor/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "libipld-cbor"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "ipld cbor codec"
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-byteorder = "1.4.3"
-libipld-core = { version = "0.16.0", path = "../core" }
-thiserror = "1.0.25"
+byteorder = { workspace = true }
+libipld-core = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4.3"
-libipld-macro = { path = "../macro" }
-multihash = "0.17.0"
-quickcheck = "1.0.3"
-serde_cbor = { version = "0.11.1", features = ["tags"] }
+hex = { workspace = true }
+libipld-macro = { workspace = true }
+multihash = { workspace = true }
+quickcheck = { workspace = true }
+serde_cbor = { workspace = true, features = ["tags"] }

--- a/dag-cbor/src/encode.rs
+++ b/dag-cbor/src/encode.rs
@@ -38,7 +38,7 @@ pub fn write_u8<W: Write>(w: &mut W, major: MajorKind, value: u8) -> Result<()> 
 
 /// Writes a u16 to a cbor encoded byte stream.
 pub fn write_u16<W: Write>(w: &mut W, major: MajorKind, value: u16) -> Result<()> {
-    if value <= u16::from(u8::max_value()) {
+    if value <= u16::from(u8::MAX) {
         write_u8(w, major, value as u8)?;
     } else {
         let mut buf = [(major as u8) << 5 | 25, 0, 0];
@@ -50,7 +50,7 @@ pub fn write_u16<W: Write>(w: &mut W, major: MajorKind, value: u16) -> Result<()
 
 /// Writes a u32 to a cbor encoded byte stream.
 pub fn write_u32<W: Write>(w: &mut W, major: MajorKind, value: u32) -> Result<()> {
-    if value <= u32::from(u16::max_value()) {
+    if value <= u32::from(u16::MAX) {
         write_u16(w, major, value as u16)?;
     } else {
         let mut buf = [(major as u8) << 5 | 26, 0, 0, 0, 0];
@@ -62,7 +62,7 @@ pub fn write_u32<W: Write>(w: &mut W, major: MajorKind, value: u32) -> Result<()
 
 /// Writes a u64 to a cbor encoded byte stream.
 pub fn write_u64<W: Write>(w: &mut W, major: MajorKind, value: u64) -> Result<()> {
-    if value <= u64::from(u32::max_value()) {
+    if value <= u64::from(u32::MAX) {
         write_u32(w, major, value as u32)?;
     } else {
         let mut buf = [(major as u8) << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -224,12 +224,12 @@ impl Encode<DagCbor> for String {
 impl Encode<DagCbor> for i128 {
     fn encode<W: Write>(&self, _: DagCbor, w: &mut W) -> Result<()> {
         if *self < 0 {
-            if -(*self + 1) > u64::max_value() as i128 {
+            if -(*self + 1) > u64::MAX as i128 {
                 return Err(NumberOutOfRange::new::<i128>().into());
             }
             write_u64(w, MajorKind::NegativeInt, -(*self + 1) as u64)?;
         } else {
-            if *self > u64::max_value() as i128 {
+            if *self > u64::MAX as i128 {
                 return Err(NumberOutOfRange::new::<i128>().into());
             }
             write_u64(w, MajorKind::UnsignedInt, *self as u64)?;

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "libipld-json"
-version = "0.16.0"
-authors = ["Irakli Gozalishvili <contact@gozala.io>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "ipld json codec"
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-libipld-core = { version = "0.16.0", path = "../core" }
-multihash = "0.18.0"
-serde_json = { version = "1.0.64", features = ["float_roundtrip"] }
-serde = { version = "1.0.126", features = ["derive"] }
+libipld-core = { workspace = true }
+multihash = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["float_roundtrip"] }

--- a/dag-pb/Cargo.toml
+++ b/dag-pb/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "libipld-pb"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "ipld protobuf codec"
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-libipld-core = { version = "0.16.0", path = "../core" }
-thiserror = "1.0.25"
-quick-protobuf = "0.8.1"
-bytes = "1.3.0"
+bytes = { workspace = true }
+libipld-core = { workspace = true }
+quick-protobuf = { workspace = true }
 
 [dev-dependencies]
-libipld-macro = { path = "../macro" }
-libipld = { path = "../" }
-multihash = "0.18.0"
-hex = "0.4.3"
+hex = { workspace = true }
+libipld = { workspace = true }
+multihash = { workspace = true }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "libipld-macro"
-version = "0.16.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "ipld macro"
-repository = "https://github.com/ipfs-rust/rust-ipld"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-libipld-core = { version = "0.16.0", path = "../core" }
+libipld-core = { workspace = true }
 
 [dev-dependencies]
-multihash = { version = "0.18.0", features = ["blake3"] }
+multihash = { workspace = true, features = ["blake3"] }

--- a/src/block.rs
+++ b/src/block.rs
@@ -195,7 +195,7 @@ mod tests {
     use crate::ipld::Ipld;
     use crate::multihash::Code;
     use crate::store::DefaultParams;
-    use fnv::FnvHashSet;
+    use ahash::HashSet;
 
     type IpldBlock = Block<DefaultParams>;
 
@@ -222,7 +222,7 @@ mod tests {
         let payload2 = block.decode::<IpldCodec, _>().unwrap();
         assert_eq!(payload, payload2);
 
-        let mut refs = FnvHashSet::default();
+        let mut refs = HashSet::default();
         payload2.references(&mut refs);
         assert_eq!(refs.len(), 3);
         assert!(refs.contains(&b1.cid));

--- a/src/block.rs
+++ b/src/block.rs
@@ -114,14 +114,11 @@ impl<S: StoreParams> Block<S> {
     }
 
     /// Encode a block.`
-    pub fn encode<CE: Codec, T: Encode<CE> + ?Sized>(
+    pub fn encode<CE: Codec + Into<S::Codecs>, T: Encode<CE> + ?Sized>(
         codec: CE,
         hcode: S::Hashes,
         payload: &T,
-    ) -> Result<Self>
-    where
-        CE: Into<S::Codecs>,
-    {
+    ) -> Result<Self> {
         debug_assert_eq!(
             Into::<u64>::into(codec),
             Into::<u64>::into(Into::<S::Codecs>::into(codec))

--- a/src/path.rs
+++ b/src/path.rs
@@ -45,15 +45,9 @@ impl From<String> for Path {
     }
 }
 
-impl ToString for Path {
-    fn to_string(&self) -> String {
-        let mut path = "".to_string();
-        for seg in &self.0 {
-            path.push_str(seg.as_str());
-            path.push('/');
-        }
-        path.pop();
-        path
+impl std::fmt::Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.as_slice().join("/"))
     }
 }
 


### PR DESCRIPTION
(Follow up https://github.com/multiformats/rust-cid/pull/165)
To prepare upgrading `cid` and `multihash`, this PR
- moves all dependencies to under `[workspace.dependency]`
- remove unused dependencies
- bump `thiserror`
- replace `fnv` with `ahash`
- move package metadata to under `[workspace.package]`
- fix or suppress clippy warnings